### PR TITLE
[Feat] #5 - UIComponent - CustomButton, CustomTextField 구현

### DIFF
--- a/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
+++ b/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
@@ -33,7 +33,6 @@
 		697815902A53015D0047944C /* MakeVibrate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6978158F2A53015D0047944C /* MakeVibrate.swift */; };
 		697815BF2A530B8F0047944C /* Lottie.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815BE2A530B8F0047944C /* Lottie.swift */; };
 		697815C32A530BB00047944C /* TabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815C22A530BB00047944C /* TabBar.swift */; };
-		697815C52A530BC10047944C /* UIComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815C42A530BC10047944C /* UIComponents.swift */; };
 		697815C72A530BC90047944C /* Splash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815C62A530BC90047944C /* Splash.swift */; };
 		697815C92A530BD00047944C /* Login.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815C82A530BD00047944C /* Login.swift */; };
 		697815CB2A530BD70047944C /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815CA2A530BD70047944C /* Entry.swift */; };
@@ -106,7 +105,6 @@
 		6978158F2A53015D0047944C /* MakeVibrate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakeVibrate.swift; sourceTree = "<group>"; };
 		697815BE2A530B8F0047944C /* Lottie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lottie.swift; sourceTree = "<group>"; };
 		697815C22A530BB00047944C /* TabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBar.swift; sourceTree = "<group>"; };
-		697815C42A530BC10047944C /* UIComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIComponents.swift; sourceTree = "<group>"; };
 		697815C62A530BC90047944C /* Splash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Splash.swift; sourceTree = "<group>"; };
 		697815C82A530BD00047944C /* Login.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Login.swift; sourceTree = "<group>"; };
 		697815CA2A530BD70047944C /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
@@ -351,7 +349,6 @@
 		697815942A53022A0047944C /* UIComponents */ = {
 			isa = PBXGroup;
 			children = (
-				697815C42A530BC10047944C /* UIComponents.swift */,
 			);
 			path = UIComponents;
 			sourceTree = "<group>";
@@ -717,7 +714,6 @@
 				697815852A5300290047944C /* UITableViewRegiseterable.swift in Sources */,
 				6978158E2A5300F90047944C /* ButtonPress.swift in Sources */,
 				697815C72A530BC90047944C /* Splash.swift in Sources */,
-				697815C52A530BC10047944C /* UIComponents.swift in Sources */,
 				697815CB2A530BD70047944C /* Entry.swift in Sources */,
 				697815F42A5311AA0047944C /* Complete.swift in Sources */,
 				697815D12A530BF10047944C /* Write.swift in Sources */,

--- a/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
+++ b/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
@@ -74,6 +74,8 @@
 		69DE6B9F2A53421D00F31812 /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 69DE6B9C2A53421C00F31812 /* Pretendard-SemiBold.otf */; };
 		69DE6BA02A53421D00F31812 /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 69DE6B9D2A53421D00F31812 /* Pretendard-Bold.otf */; };
 		69DE6BA12A53421D00F31812 /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 69DE6B9E2A53421D00F31812 /* Pretendard-Regular.otf */; };
+		69DE6BAD2A5432CC00F31812 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BAC2A5432CC00F31812 /* CustomTextField.swift */; };
+		69DE6BAF2A5432E600F31812 /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BAE2A5432E600F31812 /* CustomButton.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -131,6 +133,8 @@
 		69DE6B9C2A53421C00F31812 /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
 		69DE6B9D2A53421D00F31812 /* Pretendard-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Bold.otf"; sourceTree = "<group>"; };
 		69DE6B9E2A53421D00F31812 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
+		69DE6BAC2A5432CC00F31812 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
+		69DE6BAE2A5432E600F31812 /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -349,6 +353,8 @@
 		697815942A53022A0047944C /* UIComponents */ = {
 			isa = PBXGroup;
 			children = (
+				69DE6BAC2A5432CC00F31812 /* CustomTextField.swift */,
+				69DE6BAE2A5432E600F31812 /* CustomButton.swift */,
 			);
 			path = UIComponents;
 			sourceTree = "<group>";
@@ -702,6 +708,7 @@
 				697815752A52FF760047944C /* UIVIew+.swift in Sources */,
 				6978157F2A52FFE10047944C /* UILabel+.swift in Sources */,
 				697815BF2A530B8F0047944C /* Lottie.swift in Sources */,
+				69DE6BAD2A5432CC00F31812 /* CustomTextField.swift in Sources */,
 				697815832A53000D0047944C /* UITableView+.swift in Sources */,
 				697815692A52FE850047944C /* SizeLiterals.swift in Sources */,
 				6978156F2A52FEB00047944C /* ImageLiterals.swift in Sources */,
@@ -740,6 +747,7 @@
 				697815EE2A53117F0047944C /* UserInfo.swift in Sources */,
 				697815F82A5311C30047944C /* Quest.swift in Sources */,
 				697815CD2A530BDE0047944C /* invite.swift in Sources */,
+				69DE6BAF2A5432E600F31812 /* CustomButton.swift in Sources */,
 				697815732A52FF650047944C /* UIImage+.swift in Sources */,
 				6978156D2A52FEA00047944C /* StringLiterals.swift in Sources */,
 				697815462A52FA370047944C /* SceneDelegate.swift in Sources */,

--- a/Umbba-iOS/Umbba-iOS/Presentation/Common/UIComponents/CustomButton.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Common/UIComponents/CustomButton.swift
@@ -1,0 +1,40 @@
+//
+//  CustomButton.swift
+//  Umbba-iOS
+//
+//  Created by 최영린 on 2023/07/04.
+//
+
+import UIKit
+
+final class CustomButton: UIButton {
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    convenience init(status: Bool, title: String) {
+        self.init()
+        setUI(status: status, title: title)
+    }
+}
+
+// MARK: - Extensions
+
+private extension CustomButton {
+    func setUI(status: Bool, title: String) {
+        self.isEnabled = status
+        self.setBackgroundColor(.gray, for: .disabled)
+        self.setBackgroundColor(.black, for: .normal)
+        self.setTitle(title, for: .normal)
+        self.setTitleColor(.white, for: .normal)
+        self.titleLabel?.font = .PretendardBold(size: 16)
+        self.layer.cornerRadius = 30
+    }
+}

--- a/Umbba-iOS/Umbba-iOS/Presentation/Common/UIComponents/CustomTextField.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Common/UIComponents/CustomTextField.swift
@@ -1,0 +1,98 @@
+//
+//  CustomTextField.swift
+//  Umbba-iOS
+//
+//  Created by 최영린 on 2023/07/04.
+//
+
+import UIKit
+
+final class CustomTextField: UITextField {
+    
+    // MARK: - Properties
+    
+    @frozen
+    enum CustomTextField {
+        case normal
+        case editing
+        case uncorrectedType
+        
+        var borderColor: CGColor? {
+            switch self {
+            case .normal, .editing:
+                return UIColor.Gray500.cgColor
+            case .uncorrectedType:
+                return UIColor.Error.cgColor
+            }
+        }
+        
+        var clearButtonColor: UIColor? {
+            switch self {
+            case .normal, .editing:
+                return UIColor.Gray500
+            case .uncorrectedType:
+                return UIColor.Error
+            }
+        }
+    }
+    
+    var textFieldStatus: CustomTextField = .normal {
+        didSet {
+            updateBorderColor()
+        }
+    }
+    
+    // MARK: - UI Components
+    
+    private lazy var clearButton: UIButton = {
+        let config = UIImage.SymbolConfiguration(scale: .medium)
+        let image = UIImage(systemName: "xmark", withConfiguration: config)
+        let button = UIButton(type: .system, primaryAction: nil)
+        button.configuration = UIButton.Configuration.plain()
+        button.setImage(image, for: .normal)
+        let buttonInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 16)
+        button.largeContentImageInsets = buttonInsets
+        button.addTarget(self, action: #selector(clearButtonTapped), for: .touchUpInside)
+        button.tintColor = UIColor.Gray500
+        return button
+    }()
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    convenience init(placeHolder: String) {
+        self.init()
+        setUI(placeHolder: placeHolder)
+    }
+}
+
+// MARK: - Extensions
+
+private extension CustomTextField {
+    func setUI(placeHolder: String) {
+        self.placeholder = "\(placeHolder)"
+        self.rightView = clearButton
+        self.rightViewMode = .whileEditing
+        self.layer.cornerRadius =  24
+        self.layer.borderColor = UIColor.Gray500.cgColor
+        self.layer.borderWidth = 1
+        self.setLeftPadding(amount: 20)
+    }
+    
+    func updateBorderColor() {
+        self.layer.borderColor = textFieldStatus.borderColor
+        clearButton.tintColor = textFieldStatus.clearButtonColor
+    }
+    
+    @objc func clearButtonTapped() {
+        self.text?.removeAll()
+        self.textFieldStatus = .normal
+    }
+}

--- a/Umbba-iOS/Umbba-iOS/Presentation/Common/UIComponents/UIComponents.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Common/UIComponents/UIComponents.swift
@@ -1,8 +1,0 @@
-//
-//  UIComponents.swift
-//  Umbba-iOS
-//
-//  Created by 최영린 on 2023/07/03.
-//
-
-import Foundation


### PR DESCRIPTION
## 🔥*Pull requests*

🪵 **작업한 브랜치**
- feature/#5

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 재사용할 수 있도록 버튼, 텍스트필드를 UIComponent로 작업했습니다!!

🚨 **참고할만한 사항**
<!-- 질문할 사항이 있다면 적어주세요. -->
- 버튼 같은 경우에는 다음처럼 사용하시면 됩니다!! 
 ```swift
private lazy var nextButton: CustomButton = {
    let button = CustomButton(status: false, title: "다음으로")
    button.isEnabled = false
    return button
}()
```
- 텍스트 필드와 같은 경우에는 다음처럼 사용하시면 됩니다!!
 ```swift
private lazy var inviteTextField: CustomTextField = {
   let textField = CustomTextField(placeHolder: "placeholder입니다.")
   return textField
}()
```
- 색상, 폰트 등 디테일한 요소는 디자인 확정 후 다시 작업할 예정입니다. 

📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|button.isEnabled = true |<img src = "https://github.com/Team-Umbba/Umbba-iOS/assets/75068759/c5228fcb-7882-4040-a1dd-ae62ac1a8d60" width ="250">|
|button.isEnabled = fasle |<img src = "https://github.com/Team-Umbba/Umbba-iOS/assets/75068759/a12385f5-8f44-430b-8ab1-108754ea43d9" width ="250">|
|CustomTextField |<img src = "https://github.com/Team-Umbba/Umbba-iOS/assets/75068759/e88b6641-75fa-41e8-8d67-993d0785a448" width ="250">|


📟 **관련 이슈**
- Resolved: #5 
