### PR TITLE
[Feat] #10 - 로그인 뷰 구현

### DIFF
--- a/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
+++ b/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
@@ -34,7 +34,6 @@
 		697815BF2A530B8F0047944C /* Lottie.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815BE2A530B8F0047944C /* Lottie.swift */; };
 		697815C32A530BB00047944C /* TabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815C22A530BB00047944C /* TabBar.swift */; };
 		697815C72A530BC90047944C /* Splash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815C62A530BC90047944C /* Splash.swift */; };
-		697815C92A530BD00047944C /* Login.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815C82A530BD00047944C /* Login.swift */; };
 		697815CB2A530BD70047944C /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815CA2A530BD70047944C /* Entry.swift */; };
 		697815CD2A530BDE0047944C /* invite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815CC2A530BDE0047944C /* invite.swift */; };
 		697815CF2A530BE70047944C /* Main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815CE2A530BE70047944C /* Main.swift */; };
@@ -110,7 +109,6 @@
 		697815BE2A530B8F0047944C /* Lottie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lottie.swift; sourceTree = "<group>"; };
 		697815C22A530BB00047944C /* TabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBar.swift; sourceTree = "<group>"; };
 		697815C62A530BC90047944C /* Splash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Splash.swift; sourceTree = "<group>"; };
-		697815C82A530BD00047944C /* Login.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Login.swift; sourceTree = "<group>"; };
 		697815CA2A530BD70047944C /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
 		697815CC2A530BDE0047944C /* invite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = invite.swift; sourceTree = "<group>"; };
 		697815CE2A530BE70047944C /* Main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Main.swift; sourceTree = "<group>"; };
@@ -394,7 +392,6 @@
 			children = (
 				A42723B62A552E46003C445F /* View */,
 				A42723B92A553054003C445F /* ViewController */,
-				697815C82A530BD00047944C /* Login.swift */,
 			);
 			path = LoginScene;
 			sourceTree = "<group>";
@@ -735,7 +732,6 @@
 				697815832A53000D0047944C /* UITableView+.swift in Sources */,
 				697815692A52FE850047944C /* SizeLiterals.swift in Sources */,
 				6978156F2A52FEB00047944C /* ImageLiterals.swift in Sources */,
-				697815C92A530BD00047944C /* Login.swift in Sources */,
 				697815F22A5311A10047944C /* NoticeAlarm.swift in Sources */,
 				697815772A52FF890047944C /* UITextField+.swift in Sources */,
 				697815872A53003A0047944C /* UICollectionViewRegisterable.swift in Sources */,

--- a/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
+++ b/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
@@ -34,7 +34,6 @@
 		697815BF2A530B8F0047944C /* Lottie.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815BE2A530B8F0047944C /* Lottie.swift */; };
 		697815C32A530BB00047944C /* TabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815C22A530BB00047944C /* TabBar.swift */; };
 		697815C72A530BC90047944C /* Splash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815C62A530BC90047944C /* Splash.swift */; };
-		697815CB2A530BD70047944C /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815CA2A530BD70047944C /* Entry.swift */; };
 		697815CD2A530BDE0047944C /* invite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815CC2A530BDE0047944C /* invite.swift */; };
 		697815CF2A530BE70047944C /* Main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815CE2A530BE70047944C /* Main.swift */; };
 		697815D12A530BF10047944C /* Write.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815D02A530BF10047944C /* Write.swift */; };
@@ -77,6 +76,8 @@
 		69DE6BAF2A5432E600F31812 /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BAE2A5432E600F31812 /* CustomButton.swift */; };
 		A42723B82A552E5C003C445F /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42723B72A552E5C003C445F /* LoginView.swift */; };
 		A42723BB2A553069003C445F /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42723BA2A553069003C445F /* LoginViewController.swift */; };
+		A42723BF2A5537CD003C445F /* EntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42723BE2A5537CD003C445F /* EntryView.swift */; };
+		A42723C12A5537DA003C445F /* EntryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42723C02A5537DA003C445F /* EntryViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -109,7 +110,6 @@
 		697815BE2A530B8F0047944C /* Lottie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lottie.swift; sourceTree = "<group>"; };
 		697815C22A530BB00047944C /* TabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBar.swift; sourceTree = "<group>"; };
 		697815C62A530BC90047944C /* Splash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Splash.swift; sourceTree = "<group>"; };
-		697815CA2A530BD70047944C /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
 		697815CC2A530BDE0047944C /* invite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = invite.swift; sourceTree = "<group>"; };
 		697815CE2A530BE70047944C /* Main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Main.swift; sourceTree = "<group>"; };
 		697815D02A530BF10047944C /* Write.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Write.swift; sourceTree = "<group>"; };
@@ -137,6 +137,8 @@
 		69DE6BAE2A5432E600F31812 /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
 		A42723B72A552E5C003C445F /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		A42723BA2A553069003C445F /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
+		A42723BE2A5537CD003C445F /* EntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryView.swift; sourceTree = "<group>"; };
+		A42723C02A5537DA003C445F /* EntryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -399,7 +401,8 @@
 		6978159D2A53029D0047944C /* EntryScene */ = {
 			isa = PBXGroup;
 			children = (
-				697815CA2A530BD70047944C /* Entry.swift */,
+				A42723BC2A55378F003C445F /* View */,
+				A42723BD2A553795003C445F /* ViewController */,
 			);
 			path = EntryScene;
 			sourceTree = "<group>";
@@ -604,6 +607,22 @@
 			path = ViewController;
 			sourceTree = "<group>";
 		};
+		A42723BC2A55378F003C445F /* View */ = {
+			isa = PBXGroup;
+			children = (
+				A42723BE2A5537CD003C445F /* EntryView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		A42723BD2A553795003C445F /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				A42723C02A5537DA003C445F /* EntryViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -735,13 +754,13 @@
 				697815F22A5311A10047944C /* NoticeAlarm.swift in Sources */,
 				697815772A52FF890047944C /* UITextField+.swift in Sources */,
 				697815872A53003A0047944C /* UICollectionViewRegisterable.swift in Sources */,
+				A42723C12A5537DA003C445F /* EntryViewController.swift in Sources */,
 				697815712A52FEC10047944C /* ColorLiterals.swift in Sources */,
 				697815482A52FA370047944C /* ViewController.swift in Sources */,
 				A42723BB2A553069003C445F /* LoginViewController.swift in Sources */,
 				697815852A5300290047944C /* UITableViewRegiseterable.swift in Sources */,
 				6978158E2A5300F90047944C /* ButtonPress.swift in Sources */,
 				697815C72A530BC90047944C /* Splash.swift in Sources */,
-				697815CB2A530BD70047944C /* Entry.swift in Sources */,
 				697815F42A5311AA0047944C /* Complete.swift in Sources */,
 				697815D12A530BF10047944C /* Write.swift in Sources */,
 				697815EC2A5311770047944C /* Animation.swift in Sources */,
@@ -756,6 +775,7 @@
 				697815E32A530E140047944C /* User.swift in Sources */,
 				A42723B82A552E5C003C445F /* LoginView.swift in Sources */,
 				697815812A52FFF50047944C /* NSObject+.swift in Sources */,
+				A42723BF2A5537CD003C445F /* EntryView.swift in Sources */,
 				697815D72A530C120047944C /* Setting.swift in Sources */,
 				697815442A52FA370047944C /* AppDelegate.swift in Sources */,
 				697815F02A53118E0047944C /* FamilyInfo.swift in Sources */,

--- a/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
+++ b/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
@@ -928,9 +928,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 9YCVZHNG67;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9YCVZHNG67;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Umbba-iOS/Info.plist";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -946,6 +949,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.umbba.Umbba-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Umbba-iOS Debug";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -957,9 +962,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 9YCVZHNG67;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 9YCVZHNG67;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Umbba-iOS/Info.plist";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -975,6 +983,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.umbba.Umbba-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Umbba-iOS Debug";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
+++ b/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
@@ -76,6 +76,8 @@
 		69DE6BA12A53421D00F31812 /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 69DE6B9E2A53421D00F31812 /* Pretendard-Regular.otf */; };
 		69DE6BAD2A5432CC00F31812 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BAC2A5432CC00F31812 /* CustomTextField.swift */; };
 		69DE6BAF2A5432E600F31812 /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BAE2A5432E600F31812 /* CustomButton.swift */; };
+		A42723B82A552E5C003C445F /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42723B72A552E5C003C445F /* LoginView.swift */; };
+		A42723BB2A553069003C445F /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42723BA2A553069003C445F /* LoginViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -135,6 +137,8 @@
 		69DE6B9E2A53421D00F31812 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		69DE6BAC2A5432CC00F31812 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
 		69DE6BAE2A5432E600F31812 /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
+		A42723B72A552E5C003C445F /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		A42723BA2A553069003C445F /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -388,6 +392,8 @@
 		6978159C2A5302940047944C /* LoginScene */ = {
 			isa = PBXGroup;
 			children = (
+				A42723B62A552E46003C445F /* View */,
+				A42723B92A553054003C445F /* ViewController */,
 				697815C82A530BD00047944C /* Login.swift */,
 			);
 			path = LoginScene;
@@ -585,6 +591,22 @@
 			path = FamilyInfoScene;
 			sourceTree = "<group>";
 		};
+		A42723B62A552E46003C445F /* View */ = {
+			isa = PBXGroup;
+			children = (
+				A42723B72A552E5C003C445F /* LoginView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		A42723B92A553054003C445F /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				A42723BA2A553069003C445F /* LoginViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -681,6 +703,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		697815F92A5312CB0047944C /* SwiftLint Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -718,6 +741,7 @@
 				697815872A53003A0047944C /* UICollectionViewRegisterable.swift in Sources */,
 				697815712A52FEC10047944C /* ColorLiterals.swift in Sources */,
 				697815482A52FA370047944C /* ViewController.swift in Sources */,
+				A42723BB2A553069003C445F /* LoginViewController.swift in Sources */,
 				697815852A5300290047944C /* UITableViewRegiseterable.swift in Sources */,
 				6978158E2A5300F90047944C /* ButtonPress.swift in Sources */,
 				697815C72A530BC90047944C /* Splash.swift in Sources */,
@@ -734,6 +758,7 @@
 				697815792A52FFA20047944C /* UIButton+.swift in Sources */,
 				697815E02A530DC80047944C /* AuthService.swift in Sources */,
 				697815E32A530E140047944C /* User.swift in Sources */,
+				A42723B82A552E5C003C445F /* LoginView.swift in Sources */,
 				697815812A52FFF50047944C /* NSObject+.swift in Sources */,
 				697815D72A530C120047944C /* Setting.swift in Sources */,
 				697815442A52FA370047944C /* AppDelegate.swift in Sources */,

--- a/Umbba-iOS/Umbba-iOS/Application/SceneDelegate.swift
+++ b/Umbba-iOS/Umbba-iOS/Application/SceneDelegate.swift
@@ -14,7 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = UINavigationController(rootViewController: LoginViewController())
+        window?.rootViewController = UINavigationController(rootViewController: EntryViewController())
         window?.makeKeyAndVisible()
     }
     

--- a/Umbba-iOS/Umbba-iOS/Application/SceneDelegate.swift
+++ b/Umbba-iOS/Umbba-iOS/Application/SceneDelegate.swift
@@ -14,7 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = UINavigationController(rootViewController: ViewController())
+        window?.rootViewController = UINavigationController(rootViewController: LoginViewController())
         window?.makeKeyAndVisible()
     }
     

--- a/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
+++ b/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
@@ -13,4 +13,10 @@ struct I18N {
         static let test = "test"
     }
     
+    struct Auth {
+        static let loginTitle = "부모와 떠나는 시간 여행"
+        static let appleButtonTitle = "애플로 로그인"
+        static let kakaoButtonTitle = "카카오로 로그인"
+    }
+    
 }

--- a/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
+++ b/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
@@ -17,6 +17,10 @@ struct I18N {
         static let loginTitle = "부모와 떠나는 시간 여행"
         static let appleButtonTitle = "애플로 로그인"
         static let kakaoButtonTitle = "카카오로 로그인"
+        static let entryButtonTitle = "시작하기"
+        static let dividingText = "--------------------- or ---------------------"
+        static let inviteText = "초대 코드를 받으셨나요?"
+        static let inviteButtonTitle = "초대코드 입력하기"
     }
     
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/Entry.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/Entry.swift
@@ -1,8 +1,0 @@
-//
-//  Entry.swift
-//  Umbba-iOS
-//
-//  Created by 최영린 on 2023/07/03.
-//
-
-import Foundation

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/View/EntryView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/View/EntryView.swift
@@ -1,0 +1,120 @@
+//
+//  EntryView.swift
+//  Umbba-iOS
+//
+//  Created by 고아라 on 2023/07/05.
+//
+
+import UIKit
+
+import SnapKit
+
+final class EntryView: UIView {
+    
+    private lazy var loginViewImage: UIImageView = {
+        let image = UIImageView()
+        return image
+    }()
+    
+    private lazy var loginLabel: UILabel = {
+        let label = UILabel()
+        label.text = I18N.Auth.loginTitle
+        label.textColor = .UmbbaBlack
+        label.font = .PretendardRegular(size: 24)
+        return label
+    }()
+    
+    lazy var entryButton: UIButton = {
+        let button = CustomButton(status: true, title: I18N.Auth.entryButtonTitle)
+        button.titleLabel?.font = .PretendardRegular(size: 16)
+        button.layer.cornerRadius = 30
+        return button
+    }()
+    
+    private lazy var dividingText: UILabel = {
+        let label = UILabel()
+        label.text = I18N.Auth.dividingText
+        label.textColor = .lightGray
+        label.font = .PretendardRegular(size: 16)
+        return label
+    }()
+    
+    private lazy var inviteText: UILabel = {
+        let label = UILabel()
+        label.text = I18N.Auth.inviteText
+        label.textColor = .black
+        label.font = .systemFont(ofSize: 16)
+        return label
+    }()
+    
+    lazy var inviteButton: UIButton = {
+        let button = CustomButton(status: false, title: I18N.Auth.inviteButtonTitle)
+        button.titleLabel?.font = .PretendardRegular(size: 16)
+        button.layer.cornerRadius = 30
+        return button
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        // MARK: - addsubView
+        setHierarchy()
+        
+        // MARK: - autolayout설정
+        setLayout()
+        
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+extension EntryView {
+    
+    func setHierarchy() {
+        addSubviews(loginViewImage, loginLabel, entryButton, dividingText, inviteText, inviteButton)
+    }
+    
+    func setLayout() {
+        backgroundColor = .white
+        
+        loginViewImage.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(85)
+            $0.leading.equalToSuperview().inset(24)
+            $0.width.equalTo(86)
+            $0.height.equalTo(22)
+        }
+        
+        loginLabel.snp.makeConstraints {
+            $0.top.equalTo(loginViewImage.snp.bottom).offset(16)
+            $0.leading.equalToSuperview().inset(24)
+        }
+        
+        entryButton.snp.makeConstraints {
+            $0.bottom.equalToSuperview().inset(178)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(319)
+            $0.height.equalTo(60)
+        }
+        
+        dividingText.snp.makeConstraints {
+            $0.top.equalTo(entryButton.snp.bottom).offset(12)
+            $0.centerX.equalToSuperview()
+        }
+        
+        inviteText.snp.makeConstraints {
+            $0.top.equalTo(dividingText.snp.bottom).offset(12)
+            $0.centerX.equalToSuperview()
+        }
+        
+        inviteButton.snp.makeConstraints {
+            $0.bottom.equalToSuperview().inset(44)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(319)
+            $0.height.equalTo(60)
+        }
+    }
+
+}

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/View/EntryView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/View/EntryView.swift
@@ -69,11 +69,11 @@ final class EntryView: UIView {
 
 extension EntryView {
     
-    func setHierarchy() {
+    private func setHierarchy() {
         addSubviews(loginViewImage, loginLabel, entryButton, dividingText, inviteText, inviteButton)
     }
     
-    func setLayout() {
+    private func setLayout() {
         backgroundColor = .white
         
         loginViewImage.snp.makeConstraints {

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/View/EntryView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/View/EntryView.swift
@@ -79,8 +79,8 @@ extension EntryView {
         loginViewImage.snp.makeConstraints {
             $0.top.equalToSuperview().inset(85)
             $0.leading.equalToSuperview().inset(24)
-            $0.width.equalTo(86)
-            $0.height.equalTo(22)
+            $0.width.equalTo(SizeLiterals.Screen.screenWidth * 86 / 375)
+            $0.height.equalTo(SizeLiterals.Screen.screenHeight * 22 / 375)
         }
         
         loginLabel.snp.makeConstraints {
@@ -90,8 +90,7 @@ extension EntryView {
         
         entryButton.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(178)
-            $0.centerX.equalToSuperview()
-            $0.width.equalTo(319)
+            $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(60)
         }
         
@@ -107,8 +106,7 @@ extension EntryView {
         
         inviteButton.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(44)
-            $0.centerX.equalToSuperview()
-            $0.width.equalTo(319)
+            $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(60)
         }
     }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/View/EntryView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/View/EntryView.swift
@@ -26,8 +26,6 @@ final class EntryView: UIView {
     
     lazy var entryButton: UIButton = {
         let button = CustomButton(status: true, title: I18N.Auth.entryButtonTitle)
-        button.titleLabel?.font = .PretendardRegular(size: 16)
-        button.layer.cornerRadius = 30
         return button
     }()
     
@@ -49,8 +47,6 @@ final class EntryView: UIView {
     
     lazy var inviteButton: UIButton = {
         let button = CustomButton(status: false, title: I18N.Auth.inviteButtonTitle)
-        button.titleLabel?.font = .PretendardRegular(size: 16)
-        button.layer.cornerRadius = 30
         return button
     }()
     

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/ViewController/EntryViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/ViewController/EntryViewController.swift
@@ -1,0 +1,23 @@
+//
+//  EntryViewController.swift
+//  Umbba-iOS
+//
+//  Created by 고아라 on 2023/07/05.
+//
+
+import UIKit
+
+final class EntryViewController: UIViewController {
+
+    private let entryView = EntryView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    override func loadView() {
+        super.loadView()
+        self.view = entryView
+    }
+
+}

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/ViewController/EntryViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/ViewController/EntryViewController.swift
@@ -10,14 +10,14 @@ import UIKit
 final class EntryViewController: UIViewController {
 
     private let entryView = EntryView()
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
     
     override func loadView() {
         super.loadView()
         self.view = entryView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
     }
 
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/Login.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/Login.swift
@@ -1,8 +1,0 @@
-//
-//  Login.swift
-//  Umbba-iOS
-//
-//  Created by 최영린 on 2023/07/03.
-//
-
-import Foundation

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/View/LoginView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/View/LoginView.swift
@@ -63,8 +63,8 @@ extension LoginView {
         loginViewImage.snp.makeConstraints {
             $0.top.equalToSuperview().inset(85)
             $0.leading.equalToSuperview().inset(24)
-            $0.width.equalTo(86)
-            $0.height.equalTo(22)
+            $0.width.equalTo(SizeLiterals.Screen.screenWidth * 86 / 375)
+            $0.height.equalTo(SizeLiterals.Screen.screenHeight * 22 / 375)
         }
         
         loginLabel.snp.makeConstraints {
@@ -74,15 +74,13 @@ extension LoginView {
         
         loginAppleButton.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(116)
-            $0.centerX.equalToSuperview()
-            $0.width.equalTo(319)
+            $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(60)
         }
         
         loginKakaoButton.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(44)
-            $0.centerX.equalToSuperview()
-            $0.width.equalTo(319)
+            $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(60)
         }
     }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/View/LoginView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/View/LoginView.swift
@@ -26,17 +26,11 @@ final class LoginView: UIView {
     
     lazy var loginAppleButton: UIButton = {
         let button = CustomButton(status: false, title: I18N.Auth.appleButtonTitle)
-        button.titleLabel?.textColor = .UmbbaWhite
-        button.titleLabel?.font = .PretendardRegular(size: 16)
-        button.layer.cornerRadius = 30
         return button
     }()
     
     lazy var loginKakaoButton: UIButton = {
         let button = CustomButton(status: false, title: I18N.Auth.kakaoButtonTitle)
-        button.titleLabel?.textColor = .UmbbaWhite
-        button.titleLabel?.font = .PretendardRegular(size: 16)
-        button.layer.cornerRadius = 30
         return button
     }()
     

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/View/LoginView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/View/LoginView.swift
@@ -11,6 +11,8 @@ import SnapKit
 
 final class LoginView: UIView {
     
+    let screenSize = UIScreen.main.bounds.width
+    
     private lazy var loginViewImage: UIImageView = {
         let image = UIImageView()
         return image
@@ -25,19 +27,50 @@ final class LoginView: UIView {
     }()
     
     lazy var loginAppleButton: UIButton = {
-        let button = CustomButton(status: false, title: I18N.Auth.appleButtonTitle)
+        var config = UIButton.Configuration.plain()
+        var title = AttributedString.init(I18N.Auth.appleButtonTitle)
+        title.font = .PretendardBold(size: 16)
+        title.foregroundColor = .UmbbaWhite
+        config.attributedTitle = title
+        
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 24)
+        let image = UIImage(systemName: "apple.logo", withConfiguration: imageConfig)
+        config.image = image
+        config.imagePadding = 72 / 375 * screenSize
+        config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 0)
+        
+        let button = UIButton(configuration: config)
+        button.backgroundColor = .gray
+        button.layer.cornerRadius = 30
+        button.contentHorizontalAlignment = .left
+        
         return button
     }()
     
     lazy var loginKakaoButton: UIButton = {
-        let button = CustomButton(status: false, title: I18N.Auth.kakaoButtonTitle)
+        var config = UIButton.Configuration.plain()
+        var title = AttributedString.init(I18N.Auth.kakaoButtonTitle)
+        title.font = .PretendardBold(size: 16)
+        title.foregroundColor = .UmbbaWhite
+        config.attributedTitle = title
+        
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 24)
+        let image = UIImage(systemName: "message.fill", withConfiguration: imageConfig)
+        config.image = image
+        config.imagePadding = 72 / 375 * screenSize
+        config.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 0)
+        
+        let button = UIButton(configuration: config)
+        button.backgroundColor = .gray
+        button.layer.cornerRadius = 30
+        button.contentHorizontalAlignment = .left
         return button
     }()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        // MARK: - 컴포넌트 설정
+        // MARK: - UI Components
         setUI()
         
         // MARK: - addsubView
@@ -90,5 +123,4 @@ extension LoginView {
             $0.height.equalTo(60)
         }
     }
-
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/View/LoginView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/View/LoginView.swift
@@ -89,15 +89,15 @@ final class LoginView: UIView {
 
 extension LoginView {
     
-    func setUI() {
+    private func setUI() {
         backgroundColor = .white
     }
     
-    func setHierarchy() {
+    private func setHierarchy() {
         addSubviews(loginViewImage, loginLabel, loginAppleButton, loginKakaoButton)
     }
     
-    func setLayout() {
+    private func setLayout() {
         
         loginViewImage.snp.makeConstraints {
             $0.top.equalToSuperview().inset(85)

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/View/LoginView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/View/LoginView.swift
@@ -37,6 +37,9 @@ final class LoginView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
+        // MARK: - 컴포넌트 설정
+        setUI()
+        
         // MARK: - addsubView
         setHierarchy()
         
@@ -53,12 +56,15 @@ final class LoginView: UIView {
 
 extension LoginView {
     
+    func setUI() {
+        backgroundColor = .white
+    }
+    
     func setHierarchy() {
         addSubviews(loginViewImage, loginLabel, loginAppleButton, loginKakaoButton)
     }
     
     func setLayout() {
-        backgroundColor = .white
         
         loginViewImage.snp.makeConstraints {
             $0.top.equalToSuperview().inset(85)

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/View/LoginView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/View/LoginView.swift
@@ -1,0 +1,96 @@
+//
+//  LoginView.swift
+//  Umbba-iOS
+//
+//  Created by 고아라 on 2023/07/05.
+//
+
+import UIKit
+
+import SnapKit
+
+final class LoginView: UIView {
+    
+    private lazy var loginViewImage: UIImageView = {
+        let image = UIImageView()
+        return image
+    }()
+    
+    private lazy var loginLabel: UILabel = {
+        let label = UILabel()
+        label.text = I18N.Auth.loginTitle
+        label.textColor = .UmbbaBlack
+        label.font = .PretendardRegular(size: 24)
+        return label
+    }()
+    
+    lazy var loginAppleButton: UIButton = {
+        let button = CustomButton(status: false, title: I18N.Auth.appleButtonTitle)
+        button.titleLabel?.textColor = .UmbbaWhite
+        button.titleLabel?.font = .PretendardRegular(size: 16)
+        button.layer.cornerRadius = 30
+        return button
+    }()
+    
+    lazy var loginKakaoButton: UIButton = {
+        let button = CustomButton(status: false, title: I18N.Auth.kakaoButtonTitle)
+        button.titleLabel?.textColor = .UmbbaWhite
+        button.titleLabel?.font = .PretendardRegular(size: 16)
+        button.layer.cornerRadius = 30
+        return button
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        // MARK: - addsubView
+        setHierarchy()
+        
+        // MARK: - autolayout설정
+        setLayout()
+        
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+extension LoginView {
+    
+    func setHierarchy() {
+        addSubviews(loginViewImage, loginLabel, loginAppleButton, loginKakaoButton)
+    }
+    
+    func setLayout() {
+        backgroundColor = .white
+        
+        loginViewImage.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(85)
+            $0.leading.equalToSuperview().inset(24)
+            $0.width.equalTo(86)
+            $0.height.equalTo(22)
+        }
+        
+        loginLabel.snp.makeConstraints {
+            $0.top.equalTo(loginViewImage.snp.bottom).offset(16)
+            $0.leading.equalToSuperview().inset(24)
+        }
+        
+        loginAppleButton.snp.makeConstraints {
+            $0.bottom.equalToSuperview().inset(116)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(319)
+            $0.height.equalTo(60)
+        }
+        
+        loginKakaoButton.snp.makeConstraints {
+            $0.bottom.equalToSuperview().inset(44)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(319)
+            $0.height.equalTo(60)
+        }
+    }
+
+}

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/ViewController/LoginViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/ViewController/LoginViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class LoginViewController: UIViewController {
+final class LoginViewController: UIViewController {
     
     private let loginView = LoginView()
 

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/ViewController/LoginViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/ViewController/LoginViewController.swift
@@ -1,0 +1,23 @@
+//
+//  LoginViewController.swift
+//  Umbba-iOS
+//
+//  Created by 고아라 on 2023/07/05.
+//
+
+import UIKit
+
+class LoginViewController: UIViewController {
+    
+    private let loginView = LoginView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    override func loadView() {
+        super.loadView()
+        self.view = loginView
+    }
+
+}

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/ViewController/LoginViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/LoginScene/ViewController/LoginViewController.swift
@@ -10,14 +10,14 @@ import UIKit
 final class LoginViewController: UIViewController {
     
     private let loginView = LoginView()
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
     
     override func loadView() {
         super.loadView()
         self.view = loginView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
     }
 
 }


### PR DESCRIPTION
## 🔥*Pull requests*

🪵 **작업한 브랜치**
- feature/#10

👷 **작업한 내용**
- LoginView와 EntryView에 필요한 String은 Auth 구조체에 추가
```swift
struct Auth {
    static let loginTitle = "부모와 떠나는 시간 여행"
    static let appleButtonTitle = "애플로 로그인"
    static let kakaoButtonTitle = "카카오로 로그인"
    static let entryButtonTitle = "시작하기"
    static let dividingText = "--------------------- or ---------------------"
    static let inviteText = "초대 코드를 받으셨나요?"
    static let inviteButtonTitle = "초대코드 입력하기"
}
```
- UI 구현 완료
- 이미지 에셋이 필요한 부분 (Logo 이미지, 버튼에 들어가는 이미지)는 제외하고 구현했습니다!

🚨 **질문 사항**
- StringLiteral을 아래와 같이 쓰는게 맞는지 궁금합니다!
```
label.text = I18N.Auth.loginTitle
```

📸 **스크린샷**
|Scene|LoginScene|EntryScene|
|:--:|:--:|:--:|
|PNG|<img src = "https://github.com/Team-Umbba/Umbba-iOS/assets/79412889/d278b950-4b24-455e-869b-000709b6c282" width ="250">|<img src = "https://github.com/Team-Umbba/Umbba-iOS/assets/79412889/0cb4f2be-eb8a-4267-bf66-dd5e1aa7adf1" width ="250">|

📟 **관련 이슈**
- Resolved: #10 
