### PR TITLE
[Feat] #12 - 유저 정보 입력 뷰 구현

### DIFF
--- a/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
+++ b/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		697816182A5317C10047944C /* FirebaseInAppMessaging-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = 697816172A5317C10047944C /* FirebaseInAppMessaging-Beta */; };
 		6978161A2A5317C10047944C /* FirebaseInAppMessagingSwift-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = 697816192A5317C10047944C /* FirebaseInAppMessagingSwift-Beta */; };
 		6978161C2A5317C10047944C /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 6978161B2A5317C10047944C /* FirebaseMessaging */; };
+		6991BA6E2A5731330091D52D /* UserInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6991BA6D2A5731330091D52D /* UserInfoViewController.swift */; };
+		6991BA702A57314A0091D52D /* UserInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6991BA6F2A57314A0091D52D /* UserInfoView.swift */; };
 		69DE6B912A53384C00F31812 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6B902A53384C00F31812 /* UIColor+.swift */; };
 		69DE6B9B2A5341FF00F31812 /* Cafe24Classictype-v1.1.otf in Resources */ = {isa = PBXBuildFile; fileRef = 69DE6B9A2A5341FF00F31812 /* Cafe24Classictype-v1.1.otf */; };
 		69DE6B9F2A53421D00F31812 /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 69DE6B9C2A53421C00F31812 /* Pretendard-SemiBold.otf */; };
@@ -74,13 +76,13 @@
 		69DE6BA12A53421D00F31812 /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 69DE6B9E2A53421D00F31812 /* Pretendard-Regular.otf */; };
 		69DE6BAD2A5432CC00F31812 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BAC2A5432CC00F31812 /* CustomTextField.swift */; };
 		69DE6BAF2A5432E600F31812 /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BAE2A5432E600F31812 /* CustomButton.swift */; };
+		69DE6BB42A54400500F31812 /* InviteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BB32A54400500F31812 /* InviteView.swift */; };
+		69DE6BB62A54403200F31812 /* InviteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BB52A54403200F31812 /* InviteViewController.swift */; };
+		69DE6BB82A54417F00F31812 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BB72A54417F00F31812 /* String+.swift */; };
 		A42723B82A552E5C003C445F /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42723B72A552E5C003C445F /* LoginView.swift */; };
 		A42723BB2A553069003C445F /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42723BA2A553069003C445F /* LoginViewController.swift */; };
 		A42723BF2A5537CD003C445F /* EntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42723BE2A5537CD003C445F /* EntryView.swift */; };
 		A42723C12A5537DA003C445F /* EntryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42723C02A5537DA003C445F /* EntryViewController.swift */; };
-		69DE6BB42A54400500F31812 /* InviteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BB32A54400500F31812 /* InviteView.swift */; };
-		69DE6BB62A54403200F31812 /* InviteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BB52A54403200F31812 /* InviteViewController.swift */; };
-		69DE6BB82A54417F00F31812 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BB72A54417F00F31812 /* String+.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -131,6 +133,8 @@
 		697815F52A5311BA0047944C /* PushAlarm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushAlarm.swift; sourceTree = "<group>"; };
 		697815F72A5311C30047944C /* Quest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quest.swift; sourceTree = "<group>"; };
 		697815FA2A5314BE0047944C /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		6991BA6D2A5731330091D52D /* UserInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoViewController.swift; sourceTree = "<group>"; };
+		6991BA6F2A57314A0091D52D /* UserInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoView.swift; sourceTree = "<group>"; };
 		69DE6B902A53384C00F31812 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		69DE6B9A2A5341FF00F31812 /* Cafe24Classictype-v1.1.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Cafe24Classictype-v1.1.otf"; sourceTree = "<group>"; };
 		69DE6B9C2A53421C00F31812 /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
@@ -138,13 +142,13 @@
 		69DE6B9E2A53421D00F31812 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		69DE6BAC2A5432CC00F31812 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
 		69DE6BAE2A5432E600F31812 /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
+		69DE6BB32A54400500F31812 /* InviteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteView.swift; sourceTree = "<group>"; };
+		69DE6BB52A54403200F31812 /* InviteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteViewController.swift; sourceTree = "<group>"; };
+		69DE6BB72A54417F00F31812 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		A42723B72A552E5C003C445F /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		A42723BA2A553069003C445F /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		A42723BE2A5537CD003C445F /* EntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryView.swift; sourceTree = "<group>"; };
 		A42723C02A5537DA003C445F /* EntryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryViewController.swift; sourceTree = "<group>"; };
-		69DE6BB32A54400500F31812 /* InviteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteView.swift; sourceTree = "<group>"; };
-		69DE6BB52A54403200F31812 /* InviteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteViewController.swift; sourceTree = "<group>"; };
-		69DE6BB72A54417F00F31812 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -603,6 +607,8 @@
 		697815E92A5311090047944C /* UserInfoScene */ = {
 			isa = PBXGroup;
 			children = (
+				6991BA6C2A5730AE0091D52D /* ViewController */,
+				6991BA6B2A57303D0091D52D /* View */,
 				697815ED2A53117F0047944C /* UserInfo.swift */,
 			);
 			path = UserInfoScene;
@@ -616,18 +622,42 @@
 			path = FamilyInfoScene;
 			sourceTree = "<group>";
 		};
-		A42723B62A552E46003C445F /* View */ = {
+		6991BA6B2A57303D0091D52D /* View */ = {
 			isa = PBXGroup;
 			children = (
-				A42723B72A552E5C003C445F /* LoginView.swift */,
+				6991BA6F2A57314A0091D52D /* UserInfoView.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		6991BA6C2A5730AE0091D52D /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				6991BA6D2A5731330091D52D /* UserInfoViewController.swift */,
+			);
+			path = ViewController;
 			sourceTree = "<group>";
 		};
 		69DE6BB02A543FDF00F31812 /* View */ = {
 			isa = PBXGroup;
 			children = (
 				69DE6BB32A54400500F31812 /* InviteView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		69DE6BB12A543FE600F31812 /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				69DE6BB52A54403200F31812 /* InviteViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		A42723B62A552E46003C445F /* View */ = {
+			isa = PBXGroup;
+			children = (
+				A42723B72A552E5C003C445F /* LoginView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -652,14 +682,6 @@
 			isa = PBXGroup;
 			children = (
 				A42723C02A5537DA003C445F /* EntryViewController.swift */,
-			);
-			path = ViewController;
-			sourceTree = "<group>";
-		};
-		69DE6BB12A543FE600F31812 /* ViewController */ = {
-			isa = PBXGroup;
-			children = (
-				69DE6BB52A54403200F31812 /* InviteViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -794,6 +816,7 @@
 				697815832A53000D0047944C /* UITableView+.swift in Sources */,
 				697815692A52FE850047944C /* SizeLiterals.swift in Sources */,
 				6978156F2A52FEB00047944C /* ImageLiterals.swift in Sources */,
+				6991BA6E2A5731330091D52D /* UserInfoViewController.swift in Sources */,
 				697815772A52FF890047944C /* UITextField+.swift in Sources */,
 				697815872A53003A0047944C /* UICollectionViewRegisterable.swift in Sources */,
 				A42723C12A5537DA003C445F /* EntryViewController.swift in Sources */,
@@ -808,6 +831,7 @@
 				697815D12A530BF10047944C /* Write.swift in Sources */,
 				697815EC2A5311770047944C /* Animation.swift in Sources */,
 				697815CF2A530BE70047944C /* Main.swift in Sources */,
+				6991BA702A57314A0091D52D /* UserInfoView.swift in Sources */,
 				697815D52A530C050047944C /* Archiving.swift in Sources */,
 				697815DE2A530D2C0047944C /* NetworkResult.swift in Sources */,
 				6978156B2A52FE960047944C /* FontLiterals.swift in Sources */,

--- a/Umbba-iOS/Umbba-iOS/Global/Extension/UIVIew+.swift
+++ b/Umbba-iOS/Umbba-iOS/Global/Extension/UIVIew+.swift
@@ -18,4 +18,8 @@ extension UIView {
         layer.cornerRadius = cornerRadius
         layer.maskedCorners = CACornerMask(arrayLiteral: maskedCorners)
     }
+    
+    open override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.endEditing(true)
+    }
 }

--- a/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
+++ b/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
@@ -22,7 +22,7 @@ enum I18N {
         static let inviteError = "*올바른 초대코드 형식이 아닙니다."
         static let timeNotice = "매일 밤 11시에\n타임머신을 보내줄게"
         static let subNotice = "초대자가 선택한 시간에 따라 알림을 보내드립니다."
-        static let userInfoTitle = "환영해!\n너에 대해 알려줘"
+        static let userInfoTitle = "반가워!\n너에 대행 알고 싶어!"
         static let nameInfo = "너의 이름이 뭐야?"
         static let namePlaceholder = "이름을 입력해주세요."
         static let nameError = "*올바른 형식이 아닙니다."

--- a/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
+++ b/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
@@ -22,6 +22,16 @@ enum I18N {
         static let inviteError = "*올바른 초대코드 형식이 아닙니다."
         static let timeNotice = "매일 밤 11시에\n타임머신을 보내줄게"
         static let subNotice = "초대자가 선택한 시간에 따라 알림을 보내드립니다."
+        static let userInfoTitle = "환영해!\n너에 대해 알려줘"
+        static let nameInfo = "너의 이름이 뭐야?"
+        static let namePlaceholder = "이름을 입력해주세요."
+        static let nameError = "*올바른 형식이 아닙니다."
+        static let genderInfo = "너의 성별을 알려줘!"
+        static let male = "남자"
+        static let female = "여자"
+        static let birthInfo = "태어난 연도는 언제야?"
+        static let birthPlaceholder = "태어난 연도를 입력해주세요."
+        static let birthError = "*올바른 형식이 아닙니다."
     }
     
     struct Auth {

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/View/UserInfoView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/View/UserInfoView.swift
@@ -300,13 +300,29 @@ private extension UserInfoView {
         }
     }
     
-    func isFilledAnswer() {
-        if nameTextField.hasText && birthTextField.hasText
-            && birthTextField.textFieldStatus == .uncorrectedType || nameTextField.textFieldStatus == .uncorrectedType
-            && (maleButton.isSelected || femaleButton.isSelected) {
-            nextButton.isEnabled = true
+    func isFilledAnswer() -> Bool {
+        if nameTextField.hasText && birthTextField.hasText && (maleButton.isSelected || femaleButton.isSelected) {
+            return true
         } else {
+            return false
+        }
+    }
+    
+    func isCorrectedStatus() -> Bool {
+        if birthTextField.textFieldStatus == .normal && nameTextField.textFieldStatus == .normal {
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    func updateNextButton() {
+        if  isFilledAnswer() && !isCorrectedStatus() {
             nextButton.isEnabled = false
+        } else if !isFilledAnswer() {
+            nextButton.isEnabled = false
+        } else {
+            nextButton.isEnabled = true
         }
     }
     
@@ -322,6 +338,7 @@ private extension UserInfoView {
     
     @objc
     func genderButtonTapped(sender: UIButton) {
+        updateNextButton()
         self.selectedButton = sender.tag
         genderButton.forEach { button in
             guard let gender = button.titleLabel?.text else { return }
@@ -330,22 +347,29 @@ private extension UserInfoView {
                 print(gender)
             }
         }
-        isFilledAnswer()
     }
 }
 
 extension UserInfoView: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
-        isFilledAnswer()
-        if !nameTextField.hasText {
+        updateNextButton()
+        if nameTextField.hasText && nameTextField.text?.isOnlyKorean() == false {
+            updateNameErrorLabel(isError: true)
+        } else {
             updateNameErrorLabel(isError: false)
         }
-        if (!birthTextField.hasText) && (birthTextField.text?.count == 4) {
+        if birthTextField.hasText && (birthTextField.text?.count == 4) {
             updateBirthErrorLabel(isError: false)
+        } else if !birthTextField.hasText || birthTextField.text?.count ?? 0 < 4 {
+            birthTextField.textFieldStatus = .editing
+            self.nextButton.isEnabled = false
+        } else {
+            updateBirthErrorLabel(isError: true)
         }
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
+        updateNextButton()
         if nameTextField.hasText && nameTextField.text?.isOnlyKorean() == false {
             updateNameErrorLabel(isError: true)
         } else {
@@ -363,4 +387,3 @@ extension UserInfoView: UITextFieldDelegate {
         return true
     }
 }
-

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/View/UserInfoView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/View/UserInfoView.swift
@@ -301,11 +301,23 @@ private extension UserInfoView {
     }
     
     func isFilledAnswer() {
-        if nameTextField.hasText && birthTextField.hasText && (maleButton.isSelected || femaleButton.isSelected) {
+        if nameTextField.hasText && birthTextField.hasText
+            && birthTextField.textFieldStatus == .uncorrectedType || nameTextField.textFieldStatus == .uncorrectedType
+            && (maleButton.isSelected || femaleButton.isSelected) {
             nextButton.isEnabled = true
         } else {
             nextButton.isEnabled = false
         }
+    }
+    
+    func updateNameErrorLabel(isError: Bool) {
+        self.nameErrorLabel.isHidden = !isError
+        nameTextField.textFieldStatus = isError ? .uncorrectedType : .normal
+    }
+    
+    func updateBirthErrorLabel(isError: Bool) {
+        self.birthErrorLabel.isHidden = !isError
+        birthTextField.textFieldStatus = isError ? .uncorrectedType : .normal
     }
     
     @objc
@@ -324,36 +336,31 @@ private extension UserInfoView {
 
 extension UserInfoView: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
-            isFilledAnswer()
-            if !nameTextField.hasText {
-                self.nameErrorLabel.isHidden = true
-                nameTextField.textFieldStatus = .normal
-            }
-            if (!birthTextField.hasText) && (birthTextField.text?.count == 4) {
-                self.birthErrorLabel.isHidden = true
-                birthTextField.textFieldStatus = .normal
-            }
+        isFilledAnswer()
+        if !nameTextField.hasText {
+            updateNameErrorLabel(isError: false)
         }
-        
-        func textFieldDidEndEditing(_ textField: UITextField) {
-            if nameTextField.text?.isOnlyKorean() == false {
-                self.nameErrorLabel.isHidden = false
-                nameTextField.textFieldStatus = .uncorrectedType
-            } else {
-                self.nameErrorLabel.isHidden = true
-                nameTextField.textFieldStatus = .normal
-            }
-            if birthTextField.hasText && (birthTextField.text?.count != 4) {
-                self.birthErrorLabel.isHidden = false
-                birthTextField.textFieldStatus = .uncorrectedType
-            } else {
-                self.birthErrorLabel.isHidden = true
-                birthTextField.textFieldStatus = .normal
-            }
+        if (!birthTextField.hasText) && (birthTextField.text?.count == 4) {
+            updateBirthErrorLabel(isError: false)
         }
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        if nameTextField.hasText && nameTextField.text?.isOnlyKorean() == false {
+            updateNameErrorLabel(isError: true)
+        } else {
+            updateNameErrorLabel(isError: false)
+        }
+        if birthTextField.hasText && (birthTextField.text?.count != 4) {
+            updateBirthErrorLabel(isError: true)
+        } else {
+            updateBirthErrorLabel(isError: false)
+        }
+    }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true
     }
 }
+

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/View/UserInfoView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/View/UserInfoView.swift
@@ -323,6 +323,29 @@ private extension UserInfoView {
 }
 
 extension UserInfoView: UITextFieldDelegate {
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        isFilledAnswer()
+        if !nameTextField.hasText {
+            self.nameErrorLabel.isHidden = true
+            nameTextField.textFieldStatus = .normal
+        }
+        if (!birthTextField.hasText) && (birthTextField.text?.count == 4) {
+            self.birthErrorLabel.isHidden = true
+            birthTextField.textFieldStatus = .normal
+        }
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        if nameTextField.text?.isOnlyKorean() == false {
+            self.nameErrorLabel.isHidden = false
+            nameTextField.textFieldStatus = .uncorrectedType
+        }
+        if birthTextField.hasText && (birthTextField.text?.count != 4) {
+            self.birthErrorLabel.isHidden = false
+            birthTextField.textFieldStatus = .uncorrectedType
+        }
+    }
+    
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/View/UserInfoView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/View/UserInfoView.swift
@@ -300,6 +300,8 @@ private extension UserInfoView {
         }
     }
     
+    // MARK: - Functions
+    
     func isFilledAnswer() -> Bool {
         if nameTextField.hasText && birthTextField.hasText && (maleButton.isSelected || femaleButton.isSelected) {
             return true
@@ -336,6 +338,8 @@ private extension UserInfoView {
         birthTextField.textFieldStatus = isError ? .uncorrectedType : .normal
     }
     
+    // MARK: - @objc Functions
+    
     @objc
     func genderButtonTapped(sender: UIButton) {
         updateNextButton()
@@ -349,6 +353,8 @@ private extension UserInfoView {
         }
     }
 }
+
+// MARK: - TextFieldDelegate
 
 extension UserInfoView: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/View/UserInfoView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/View/UserInfoView.swift
@@ -1,0 +1,307 @@
+//
+//  UserInfoView.swift
+//  Umbba-Lab
+//
+//  Created by 최영린 on 2023/07/06.
+//
+
+import UIKit
+
+final class UserInfoView: UIView {
+    
+    // MARK: - UI Components
+    
+    private let userInfoTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = I18N.Onboarding.userInfoTitle
+        label.font = .PretendardRegular(size: 24)
+        label.setLineSpacingPartFontChange(lineSpacing: 5.0, targetString: "너", font: .PretendardBold(size: 24))
+        label.numberOfLines = 0
+        return label
+    }()
+    
+    private lazy var scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.backgroundColor = .white
+        scrollView.showsVerticalScrollIndicator = false
+        return scrollView
+    }()
+    
+    private let contentView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let nameView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.layer.cornerRadius = 8
+        view.layer.borderWidth = 1
+        view.layer.borderColor = UIColor.Gray400.cgColor
+        view.layer.masksToBounds = true
+        return view
+    }()
+    
+    private let nameLabel: UILabel = {
+        let label = UILabel()
+        label.text = I18N.Onboarding.nameInfo
+        label.textColor = .UmbbaBlack
+        label.font = .PretendardSemiBold(size: 20)
+        return label
+    }()
+    
+    private lazy var nameTextField: CustomTextField = {
+        let textField = CustomTextField(placeHolder: I18N.Onboarding.namePlaceholder)
+        return textField
+    }()
+    
+    private let nameErrorLabel: UILabel = {
+        let label = UILabel()
+        label.text = I18N.Onboarding.nameError
+        label.font = .PretendardRegular(size: 12)
+        label.textColor = UIColor.Error
+        label.isHidden = true
+        return label
+    }()
+    
+    private let genderView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.layer.cornerRadius = 8
+        view.layer.borderWidth = 1
+        view.layer.borderColor = UIColor.Gray400.cgColor
+        view.layer.masksToBounds = true
+        return view
+    }()
+    
+    private let genderLabel: UILabel = {
+        let label = UILabel()
+        label.text = I18N.Onboarding.genderInfo
+        label.textColor = .black
+        label.font = .PretendardSemiBold(size: 20)
+        return label
+    }()
+    
+    private lazy var maleButton: UIButton = {
+        let button = UIButton()
+        button.setBackgroundColor(.Gray300, for: .normal)
+        button.setBackgroundColor(.Gray500, for: .selected)
+        button.setTitle(I18N.Onboarding.male, for: .normal)
+        button.setTitleColor(.UmbbaBlack, for: .normal)
+        button.setTitleColor(.UmbbaWhite, for: .selected)
+        button.titleLabel?.font = .PretendardRegular(size: 16)
+        button.layer.cornerRadius = 24
+        return button
+    }()
+    
+    private lazy var femaleButton: UIButton = {
+        let button = UIButton()
+        button.setBackgroundColor(.Gray300, for: .normal)
+        button.setBackgroundColor(.Gray500, for: .selected)
+        button.setTitle(I18N.Onboarding.female, for: .normal)
+        button.setTitleColor(.UmbbaBlack, for: .normal)
+        button.setTitleColor(.UmbbaWhite, for: .selected)
+        button.titleLabel?.font = .PretendardRegular(size: 16)
+        button.layer.cornerRadius = 24
+        return button
+    }()
+    
+    private lazy var genderStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.distribution = .fillEqually
+        stackView.spacing = 13
+        stackView.addArrangedSubviews(maleButton, femaleButton)
+        return stackView
+    }()
+    
+    private let birthView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.layer.cornerRadius = 8
+        view.layer.borderWidth = 1
+        view.layer.borderColor = UIColor.Gray400.cgColor
+        view.layer.masksToBounds = true
+        return view
+    }()
+    
+    private let birthLabel: UILabel = {
+        let label = UILabel()
+        label.text = I18N.Onboarding.birthInfo
+        label.textColor = .black
+        label.font = .PretendardSemiBold(size: 20)
+        return label
+    }()
+    
+    private lazy var birthTextField: CustomTextField = {
+        let textField = CustomTextField(placeHolder: I18N.Onboarding.birthPlaceholder)
+        textField.keyboardType = .numberPad
+        return textField
+    }()
+    
+    private let birthErrorLabel: UILabel = {
+        let label = UILabel()
+        label.text = I18N.Onboarding.birthError
+        label.font = .PretendardRegular(size: 12)
+        label.textColor = UIColor.Error
+        label.isHidden = true
+        return label
+    }()
+    
+    private lazy var infoStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.spacing = 12
+        stackView.addArrangedSubviews(nameView, genderView, birthView)
+        return stackView
+    }()
+    
+    lazy var nextButton: CustomButton = {
+        let button = CustomButton(status: false, title: I18N.Common.nextButtonTitle)
+        button.isEnabled = false
+        return button
+    }()
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setDelegate()
+        setAddTarget()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Extensions
+
+private extension UserInfoView {
+    func setUI() {
+        self.backgroundColor = .UmbbaWhite
+    }
+    
+    func setDelegate() {
+        nameTextField.delegate = self
+        birthTextField.delegate = self
+    }
+    
+    func setAddTarget() {
+        maleButton.addTarget(self, action: #selector(genderButtonTapped), for: .touchUpInside)
+        femaleButton.addTarget(self, action: #selector(genderButtonTapped), for: .touchUpInside)
+    }
+    
+    func setLayout() {
+        self.addSubviews(userInfoTitleLabel, scrollView, nextButton)
+        scrollView.addSubview(contentView)
+        contentView.addSubviews(infoStackView)
+        nameView.addSubviews(nameLabel, nameTextField, nameErrorLabel)
+        genderView.addSubviews(genderLabel, genderStackView)
+        birthView.addSubviews(birthLabel, birthTextField, birthErrorLabel)
+        
+        userInfoTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(self.safeAreaLayoutGuide).inset(12)
+            $0.leading.equalToSuperview().inset(24)
+        }
+        
+        scrollView.snp.makeConstraints { make in
+            make.top.equalTo(userInfoTitleLabel.snp.bottom).offset(20)
+            make.bottom.leading.trailing.equalToSuperview()
+        }
+        
+        contentView.snp.makeConstraints { make in
+            make.edges.equalTo(scrollView.contentLayoutGuide)
+            make.height.greaterThanOrEqualTo(self.snp.height).priority(.low)
+            make.width.equalTo(scrollView.snp.width)
+        }
+        
+        infoStackView.snp.makeConstraints {
+            $0.top.bottom.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(24)
+        }
+        
+        nameView.snp.makeConstraints {
+            $0.height.equalTo(136)
+        }
+        
+        nameLabel.snp.makeConstraints {
+            $0.top.leading.equalToSuperview().inset(24)
+        }
+        
+        nameTextField.snp.makeConstraints {
+            $0.top.equalTo(nameLabel.snp.bottom).offset(12)
+            $0.trailing.leading.equalToSuperview().inset(20)
+            $0.height.equalTo(48)
+        }
+        
+        nameErrorLabel.snp.makeConstraints {
+            $0.top.equalTo(nameTextField.snp.bottom).offset(4)
+            $0.leading.equalTo(nameTextField.snp.leading).offset(20)
+        }
+        
+        genderView.snp.makeConstraints {
+            $0.height.equalTo(136)
+        }
+        
+        genderLabel.snp.makeConstraints {
+            $0.top.leading.equalToSuperview().inset(24)
+        }
+        
+        maleButton.snp.makeConstraints {
+            $0.height.equalTo(48)
+        }
+        
+        femaleButton.snp.makeConstraints {
+            $0.height.equalTo(48)
+        }
+        
+        genderStackView.snp.makeConstraints {
+            $0.top.equalTo(genderLabel.snp.bottom).offset(12)
+            $0.leading.trailing.equalToSuperview().inset(25)
+        }
+        
+        birthView.snp.makeConstraints {
+            $0.height.equalTo(136)
+        }
+        
+        birthLabel.snp.makeConstraints {
+            $0.top.leading.equalToSuperview().inset(24)
+        }
+        
+        birthTextField.snp.makeConstraints {
+            $0.top.equalTo(birthLabel.snp.bottom).offset(12)
+            $0.trailing.leading.equalToSuperview().inset(20)
+            $0.height.equalTo(48)
+        }
+        
+        birthErrorLabel.snp.makeConstraints {
+            $0.top.equalTo(birthTextField.snp.bottom).offset(4)
+            $0.leading.equalTo(birthTextField.snp.leading).offset(20)
+        }
+        
+        nextButton.snp.makeConstraints {
+            $0.bottom.equalTo(self.safeAreaLayoutGuide).offset(-12)
+            $0.trailing.leading.equalToSuperview().inset(20)
+            $0.height.equalTo(60)
+        }
+    }
+    
+    @objc
+    func genderButtonTapped(sender: UIButton) {
+        print("성별 버튼 클릭")
+    }
+}
+
+extension UserInfoView: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+}

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/View/UserInfoView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/View/UserInfoView.swift
@@ -9,6 +9,11 @@ import UIKit
 
 final class UserInfoView: UIView {
     
+    // MARK: - Properties
+    
+    private var selectedButton: Int = 0
+    private var genderButton: [UIButton] = []
+    
     // MARK: - UI Components
     
     private let userInfoTitleLabel: UILabel = {
@@ -93,6 +98,7 @@ final class UserInfoView: UIView {
         button.setTitleColor(.UmbbaWhite, for: .selected)
         button.titleLabel?.font = .PretendardRegular(size: 16)
         button.layer.cornerRadius = 24
+        genderButton.append(button)
         return button
     }()
     
@@ -105,6 +111,7 @@ final class UserInfoView: UIView {
         button.setTitleColor(.UmbbaWhite, for: .selected)
         button.titleLabel?.font = .PretendardRegular(size: 16)
         button.layer.cornerRadius = 24
+        genderButton.append(button)
         return button
     }()
     
@@ -293,9 +300,25 @@ private extension UserInfoView {
         }
     }
     
+    func isFilledAnswer() {
+        if nameTextField.hasText && birthTextField.hasText && (maleButton.isSelected || femaleButton.isSelected) {
+            nextButton.isEnabled = true
+        } else {
+            nextButton.isEnabled = false
+        }
+    }
+    
     @objc
     func genderButtonTapped(sender: UIButton) {
-        print("성별 버튼 클릭")
+        self.selectedButton = sender.tag
+        genderButton.forEach { button in
+            guard let gender = button.titleLabel?.text else { return }
+            button.isSelected = sender == button
+            if button.isSelected {
+                print(gender)
+            }
+        }
+        isFilledAnswer()
     }
 }
 

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/View/UserInfoView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/View/UserInfoView.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import SnapKit
+
 final class UserInfoView: UIView {
     
     // MARK: - Properties

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/View/UserInfoView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/View/UserInfoView.swift
@@ -324,27 +324,33 @@ private extension UserInfoView {
 
 extension UserInfoView: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
-        isFilledAnswer()
-        if !nameTextField.hasText {
-            self.nameErrorLabel.isHidden = true
-            nameTextField.textFieldStatus = .normal
+            isFilledAnswer()
+            if !nameTextField.hasText {
+                self.nameErrorLabel.isHidden = true
+                nameTextField.textFieldStatus = .normal
+            }
+            if (!birthTextField.hasText) && (birthTextField.text?.count == 4) {
+                self.birthErrorLabel.isHidden = true
+                birthTextField.textFieldStatus = .normal
+            }
         }
-        if (!birthTextField.hasText) && (birthTextField.text?.count == 4) {
-            self.birthErrorLabel.isHidden = true
-            birthTextField.textFieldStatus = .normal
+        
+        func textFieldDidEndEditing(_ textField: UITextField) {
+            if nameTextField.text?.isOnlyKorean() == false {
+                self.nameErrorLabel.isHidden = false
+                nameTextField.textFieldStatus = .uncorrectedType
+            } else {
+                self.nameErrorLabel.isHidden = true
+                nameTextField.textFieldStatus = .normal
+            }
+            if birthTextField.hasText && (birthTextField.text?.count != 4) {
+                self.birthErrorLabel.isHidden = false
+                birthTextField.textFieldStatus = .uncorrectedType
+            } else {
+                self.birthErrorLabel.isHidden = true
+                birthTextField.textFieldStatus = .normal
+            }
         }
-    }
-    
-    func textFieldDidEndEditing(_ textField: UITextField) {
-        if nameTextField.text?.isOnlyKorean() == false {
-            self.nameErrorLabel.isHidden = false
-            nameTextField.textFieldStatus = .uncorrectedType
-        }
-        if birthTextField.hasText && (birthTextField.text?.count != 4) {
-            self.birthErrorLabel.isHidden = false
-            birthTextField.textFieldStatus = .uncorrectedType
-        }
-    }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/ViewController/UserInfoViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/ViewController/UserInfoViewController.swift
@@ -1,0 +1,41 @@
+//
+//  UserInfoViewController.swift
+//  Umbba-Lab
+//
+//  Created by 최영린 on 2023/07/06.
+//
+
+import UIKit
+
+final class UserInfoViewController: UIViewController {
+    
+    private let userInfoView = UserInfoView()
+    private lazy var nextButton = userInfoView.nextButton
+    
+    override func loadView() {
+        super.loadView()
+        
+        view = userInfoView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setNavigationUI()
+    }
+}
+
+// MARK: - Methods
+
+extension UserInfoViewController {
+    func setNavigationUI() {
+        navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "arrow.backward"), style: .plain, target: self, action: #selector(backButtonTapped))
+        navigationItem.leftBarButtonItem?.tintColor = .black
+    }
+    
+    @objc
+    func backButtonTapped() {
+        print("이전 화면으로 이동")
+        self.navigationController?.popViewController(animated: true)
+    }
+}

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/ViewController/UserInfoViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/ViewController/UserInfoViewController.swift
@@ -9,8 +9,12 @@ import UIKit
 
 final class UserInfoViewController: UIViewController {
     
+    // MARK: - UI Components
+    
     private let userInfoView = UserInfoView()
     private lazy var nextButton = userInfoView.nextButton
+    
+    // MARK: - Life Cycles
     
     override func loadView() {
         super.loadView()
@@ -25,7 +29,7 @@ final class UserInfoViewController: UIViewController {
     }
 }
 
-// MARK: - Methods
+// MARK: - Extensions
 
 extension UserInfoViewController {
     func setNavigationUI() {


### PR DESCRIPTION
## 🔥*Pull requests*

🪵 **작업한 브랜치**
- feature/#12

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 유저 정보 입력 뷰 구현
- 전체 스크롤뷰 안에 각 질문들을 StackView로 묶어서 작업했습니다. 
- 각 TextField 입력 시에 errorLabel 및 nextButton 처리 하였습니다.

🚨 **참고 / 질문**
<!-- 질문할 사항이 있다면 적어주세요. -->
- 키보드 처리는 지난 번 초대입력뷰 키보드와 함께 사용할 수 있는 방법을 더 고민해보고 구현하겠습니다.
- 각 상황에 따른 errorLabel , nextButton의 변화가 많아서 가독성이 조금 떨어져요..  이 부분을더 깔끔한 코드로 작성하고 싶은데 리뷰 달아주시면 감사하겠습니다 !! 
- 현재 각 TextField의 형식이 확정나지 않아 이름과 같은 경우에는 한글외의 문자 입력시 오류, 연도의 경우에는 4자리가 아닌 경우 오류로 처리해두었습니다!! 

📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|유저 정보 입력 뷰|<img src = "https://github.com/Team-Umbba/Umbba-iOS/assets/75068759/7d27be69-4e89-44d2-b61c-8da2e903763d" width ="250">|
|GIF|<img src = "https://github.com/Team-Umbba/Umbba-iOS/assets/75068759/e7c04e64-17e6-410a-a3eb-c014eee79080" width ="250">|

📟 **관련 이슈**
- Resolved: #12 
