### PR TITLE
[Feat] #14 - 설정 뷰 구현

### DIFF
--- a/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
+++ b/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
@@ -7,8 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		14A01D432A57D8A200D4F860 /* SettingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A01D422A57D8A200D4F860 /* SettingTableViewCell.swift */; };
 		14AA29842A5685050038CDA1 /* NoticeAlarmViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14AA29832A5685050038CDA1 /* NoticeAlarmViewController.swift */; };
 		14AA29862A5685660038CDA1 /* NoticeAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14AA29852A5685660038CDA1 /* NoticeAlarmView.swift */; };
+		14AC19B32A57C27600A01E4F /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14AC19B22A57C27600A01E4F /* SettingViewController.swift */; };
 		697815442A52FA370047944C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815432A52FA370047944C /* AppDelegate.swift */; };
 		697815462A52FA370047944C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815452A52FA370047944C /* SceneDelegate.swift */; };
 		697815482A52FA370047944C /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697815472A52FA370047944C /* ViewController.swift */; };
@@ -74,18 +76,20 @@
 		69DE6BA12A53421D00F31812 /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 69DE6B9E2A53421D00F31812 /* Pretendard-Regular.otf */; };
 		69DE6BAD2A5432CC00F31812 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BAC2A5432CC00F31812 /* CustomTextField.swift */; };
 		69DE6BAF2A5432E600F31812 /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BAE2A5432E600F31812 /* CustomButton.swift */; };
+		69DE6BB42A54400500F31812 /* InviteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BB32A54400500F31812 /* InviteView.swift */; };
+		69DE6BB62A54403200F31812 /* InviteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BB52A54403200F31812 /* InviteViewController.swift */; };
+		69DE6BB82A54417F00F31812 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BB72A54417F00F31812 /* String+.swift */; };
 		A42723B82A552E5C003C445F /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42723B72A552E5C003C445F /* LoginView.swift */; };
 		A42723BB2A553069003C445F /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42723BA2A553069003C445F /* LoginViewController.swift */; };
 		A42723BF2A5537CD003C445F /* EntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42723BE2A5537CD003C445F /* EntryView.swift */; };
 		A42723C12A5537DA003C445F /* EntryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42723C02A5537DA003C445F /* EntryViewController.swift */; };
-		69DE6BB42A54400500F31812 /* InviteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BB32A54400500F31812 /* InviteView.swift */; };
-		69DE6BB62A54403200F31812 /* InviteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BB52A54403200F31812 /* InviteViewController.swift */; };
-		69DE6BB82A54417F00F31812 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DE6BB72A54417F00F31812 /* String+.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		14A01D422A57D8A200D4F860 /* SettingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTableViewCell.swift; sourceTree = "<group>"; };
 		14AA29832A5685050038CDA1 /* NoticeAlarmViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeAlarmViewController.swift; sourceTree = "<group>"; };
 		14AA29852A5685660038CDA1 /* NoticeAlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeAlarmView.swift; sourceTree = "<group>"; };
+		14AC19B22A57C27600A01E4F /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
 		697815402A52FA370047944C /* Umbba-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Umbba-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		697815432A52FA370047944C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		697815452A52FA370047944C /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -138,13 +142,13 @@
 		69DE6B9E2A53421D00F31812 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		69DE6BAC2A5432CC00F31812 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
 		69DE6BAE2A5432E600F31812 /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
+		69DE6BB32A54400500F31812 /* InviteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteView.swift; sourceTree = "<group>"; };
+		69DE6BB52A54403200F31812 /* InviteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteViewController.swift; sourceTree = "<group>"; };
+		69DE6BB72A54417F00F31812 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		A42723B72A552E5C003C445F /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		A42723BA2A553069003C445F /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		A42723BE2A5537CD003C445F /* EntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryView.swift; sourceTree = "<group>"; };
 		A42723C02A5537DA003C445F /* EntryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryViewController.swift; sourceTree = "<group>"; };
-		69DE6BB32A54400500F31812 /* InviteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteView.swift; sourceTree = "<group>"; };
-		69DE6BB52A54403200F31812 /* InviteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteViewController.swift; sourceTree = "<group>"; };
-		69DE6BB72A54417F00F31812 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -187,6 +191,22 @@
 				14AA29832A5685050038CDA1 /* NoticeAlarmViewController.swift */,
 			);
 			path = ViewController;
+			sourceTree = "<group>";
+		};
+		14AC19B02A57C23900A01E4F /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				14AC19B22A57C27600A01E4F /* SettingViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		14AC19B12A57C24300A01E4F /* View */ = {
+			isa = PBXGroup;
+			children = (
+				14A01D422A57D8A200D4F860 /* SettingTableViewCell.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 		697815372A52FA370047944C = {
@@ -498,6 +518,8 @@
 		697815AB2A53049A0047944C /* SettingScene */ = {
 			isa = PBXGroup;
 			children = (
+				14AC19B12A57C24300A01E4F /* View */,
+				14AC19B02A57C23900A01E4F /* ViewController */,
 				697815D62A530C120047944C /* Setting.swift */,
 			);
 			path = SettingScene;
@@ -616,18 +638,26 @@
 			path = FamilyInfoScene;
 			sourceTree = "<group>";
 		};
-		A42723B62A552E46003C445F /* View */ = {
-			isa = PBXGroup;
-			children = (
-				A42723B72A552E5C003C445F /* LoginView.swift */,
-			);
-			path = View;
-			sourceTree = "<group>";
-		};
 		69DE6BB02A543FDF00F31812 /* View */ = {
 			isa = PBXGroup;
 			children = (
 				69DE6BB32A54400500F31812 /* InviteView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		69DE6BB12A543FE600F31812 /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				69DE6BB52A54403200F31812 /* InviteViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		A42723B62A552E46003C445F /* View */ = {
+			isa = PBXGroup;
+			children = (
+				A42723B72A552E5C003C445F /* LoginView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -652,14 +682,6 @@
 			isa = PBXGroup;
 			children = (
 				A42723C02A5537DA003C445F /* EntryViewController.swift */,
-			);
-			path = ViewController;
-			sourceTree = "<group>";
-		};
-		69DE6BB12A543FE600F31812 /* ViewController */ = {
-			isa = PBXGroup;
-			children = (
-				69DE6BB52A54403200F31812 /* InviteViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -795,6 +817,7 @@
 				697815692A52FE850047944C /* SizeLiterals.swift in Sources */,
 				6978156F2A52FEB00047944C /* ImageLiterals.swift in Sources */,
 				697815772A52FF890047944C /* UITextField+.swift in Sources */,
+				14A01D432A57D8A200D4F860 /* SettingTableViewCell.swift in Sources */,
 				697815872A53003A0047944C /* UICollectionViewRegisterable.swift in Sources */,
 				A42723C12A5537DA003C445F /* EntryViewController.swift in Sources */,
 				697815712A52FEC10047944C /* ColorLiterals.swift in Sources */,
@@ -825,6 +848,7 @@
 				697815F02A53118E0047944C /* FamilyInfo.swift in Sources */,
 				6978157D2A52FFCB0047944C /* UIStackView+.swift in Sources */,
 				697815F62A5311BA0047944C /* PushAlarm.swift in Sources */,
+				14AC19B32A57C27600A01E4F /* SettingViewController.swift in Sources */,
 				697815C32A530BB00047944C /* TabBar.swift in Sources */,
 				697815DC2A530CF70047944C /* Config.swift in Sources */,
 				69DE6B912A53384C00F31812 /* UIColor+.swift in Sources */,

--- a/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
+++ b/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		14A01D432A57D8A200D4F860 /* SettingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A01D422A57D8A200D4F860 /* SettingTableViewCell.swift */; };
+		14A6D3062A5A63EF003A83B3 /* SettingSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A6D3052A5A63EF003A83B3 /* SettingSectionHeaderView.swift */; };
 		14AA29842A5685050038CDA1 /* NoticeAlarmViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14AA29832A5685050038CDA1 /* NoticeAlarmViewController.swift */; };
 		14AA29862A5685660038CDA1 /* NoticeAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14AA29852A5685660038CDA1 /* NoticeAlarmView.swift */; };
 		14AC19B32A57C27600A01E4F /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14AC19B22A57C27600A01E4F /* SettingViewController.swift */; };
@@ -87,6 +88,7 @@
 
 /* Begin PBXFileReference section */
 		14A01D422A57D8A200D4F860 /* SettingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTableViewCell.swift; sourceTree = "<group>"; };
+		14A6D3052A5A63EF003A83B3 /* SettingSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingSectionHeaderView.swift; sourceTree = "<group>"; };
 		14AA29832A5685050038CDA1 /* NoticeAlarmViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeAlarmViewController.swift; sourceTree = "<group>"; };
 		14AA29852A5685660038CDA1 /* NoticeAlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeAlarmView.swift; sourceTree = "<group>"; };
 		14AC19B22A57C27600A01E4F /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
@@ -205,6 +207,7 @@
 			isa = PBXGroup;
 			children = (
 				14A01D422A57D8A200D4F860 /* SettingTableViewCell.swift */,
+				14A6D3052A5A63EF003A83B3 /* SettingSectionHeaderView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -830,6 +833,7 @@
 				697815F42A5311AA0047944C /* Complete.swift in Sources */,
 				697815D12A530BF10047944C /* Write.swift in Sources */,
 				697815EC2A5311770047944C /* Animation.swift in Sources */,
+				14A6D3062A5A63EF003A83B3 /* SettingSectionHeaderView.swift in Sources */,
 				697815CF2A530BE70047944C /* Main.swift in Sources */,
 				697815D52A530C050047944C /* Archiving.swift in Sources */,
 				697815DE2A530D2C0047944C /* NetworkResult.swift in Sources */,

--- a/Umbba-iOS/Umbba-iOS/Application/SceneDelegate.swift
+++ b/Umbba-iOS/Umbba-iOS/Application/SceneDelegate.swift
@@ -14,7 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = UINavigationController(rootViewController: EntryViewController())
+        window?.rootViewController = UINavigationController(rootViewController: ViewController())
         window?.makeKeyAndVisible()
     }
     

--- a/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
+++ b/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
@@ -36,6 +36,7 @@ enum I18N {
     
     struct Setting {
         static let settingTitle = "설정"
+        static let settingLabel = "알람 설정"
     }
     
 }

--- a/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
+++ b/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
@@ -34,7 +34,7 @@ enum I18N {
         static let inviteButtonTitle = "초대코드 입력하기"
     }
     
-    struct Setting {
+    enum Setting {
         static let settingTitle = "설정"
         static let settingLabel = "알람 설정"
     }

--- a/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
+++ b/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
@@ -34,4 +34,8 @@ enum I18N {
         static let inviteButtonTitle = "초대코드 입력하기"
     }
     
+    struct Setting {
+        static let settingTitle = "설정"
+    }
+    
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/Setting.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/Setting.swift
@@ -5,4 +5,17 @@
 //  Created by 최영린 on 2023/07/03.
 //
 
-import Foundation
+import UIKit
+
+struct Setting {
+    let title: String
+}
+
+extension Setting {
+    static func dummy() -> [Setting] {
+        return [Setting(title: "About 엄빠도 어렸다"),
+                Setting(title: "이용약관"),
+                Setting(title: "공지사항")
+        ]
+    }
+}

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingSectionHeaderView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingSectionHeaderView.swift
@@ -9,8 +9,12 @@ import UIKit
 
 import SnapKit
 
-class SettingSectionHeaderView: UIView {
-
+class SettingSectionHeaderView: UITableViewHeaderFooterView, UITableViewHeaderFooterRegisterable {
+   
+    // MARK: - Properties
+    
+    static var isFromNib = false
+    
     // MARK: - UI Components
     
     private let settingLabel: UILabel = {
@@ -26,8 +30,8 @@ class SettingSectionHeaderView: UIView {
         return mySwitch
     }()
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
        
         setUI()
         setLayout()

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingSectionHeaderView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingSectionHeaderView.swift
@@ -1,0 +1,50 @@
+//
+//  SettingSectionHeaderView.swift
+//  Umbba-iOS
+//
+//  Created by 남유진 on 2023/07/09.
+//
+
+import UIKit
+
+import SnapKit
+
+class SettingSectionHeaderView: UIView {
+
+    // MARK: - UI Components
+    
+    private let settingLabel: UILabel = {
+        let label = UILabel()
+        label.text = I18N.Setting.settingLabel
+        label.font = .PretendardRegular(size: 16)
+        label.textColor = .gray
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+       
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension SettingSectionHeaderView {
+    
+    func setUI() {
+        backgroundColor = .white
+    }
+    
+    func setLayout() {
+        addSubview(settingLabel)
+        
+        settingLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().offset(24)
+        }
+    }
+}

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingSectionHeaderView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingSectionHeaderView.swift
@@ -21,6 +21,11 @@ class SettingSectionHeaderView: UIView {
         return label
     }()
     
+    private lazy var alarmSwitch: UISwitch = {
+        let mySwitch = UISwitch()
+        return mySwitch
+    }()
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
        
@@ -40,11 +45,16 @@ extension SettingSectionHeaderView {
     }
     
     func setLayout() {
-        addSubview(settingLabel)
+        addSubviews(settingLabel, alarmSwitch)
         
         settingLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.leading.equalToSuperview().offset(24)
+        }
+        
+        alarmSwitch.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().offset(-24)
         }
     }
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingSectionHeaderView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingSectionHeaderView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-class SettingSectionHeaderView: UITableViewHeaderFooterView, UITableViewHeaderFooterRegisterable {
+final class SettingSectionHeaderView: UITableViewHeaderFooterView, UITableViewHeaderFooterRegisterable {
    
     // MARK: - Properties
     
@@ -30,6 +30,8 @@ class SettingSectionHeaderView: UITableViewHeaderFooterView, UITableViewHeaderFo
         return mySwitch
     }()
     
+    // MARK: - Life Cycles
+    
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
        
@@ -42,7 +44,9 @@ class SettingSectionHeaderView: UITableViewHeaderFooterView, UITableViewHeaderFo
     }
 }
 
-extension SettingSectionHeaderView {
+// MARK: - Extensions
+
+private extension SettingSectionHeaderView {
     
     func setUI() {
         backgroundColor = .white
@@ -58,7 +62,7 @@ extension SettingSectionHeaderView {
         
         alarmSwitch.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.trailing.equalToSuperview().offset(-24)
+            $0.trailing.equalToSuperview().inset(24)
         }
     }
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableViewCell.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableViewCell.swift
@@ -24,7 +24,7 @@ class SettingTableViewCell: UITableViewCell {
     
     private lazy var buttonImage: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = UIImage(systemName: "arrow_forward")?.withTintColor(.gray, renderingMode: .alwaysOriginal)
+        imageView.image = UIImage(systemName: "chevron.compact.right")?.withTintColor(.gray, renderingMode: .alwaysOriginal)
         return imageView
     }()
     

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableViewCell.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableViewCell.swift
@@ -1,0 +1,70 @@
+//
+//  SettingTableViewCell.swift
+//  Umbba-iOS
+//
+//  Created by 남유진 on 2023/07/07.
+//
+
+import UIKit
+
+import SnapKit
+
+class SettingTableViewCell: UITableViewCell {
+
+    static let identifier = "SettingTableViewCell"
+    
+    // MARK: - UI Components
+    
+    let contentLabel: UILabel = {
+        let label = UILabel()
+        label.font = .PretendardRegular(size: 16)
+        label.textColor = .gray
+        return label
+    }()
+    
+    private lazy var buttonImage: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "arrow_forward")?.withTintColor(.gray, renderingMode: .alwaysOriginal)
+        return imageView
+    }()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        setUI()
+        setLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}
+
+extension SettingTableViewCell {
+    
+    func setUI() {
+        contentView.backgroundColor = .white
+        separatorInset.left = 0
+        selectionStyle = .none
+    }
+    
+    func setLayout() {
+        contentView.addSubviews(contentLabel, buttonImage)
+        
+        contentLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().offset(24)
+        }
+        
+        buttonImage.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().offset(-24)
+            $0.size.equalTo(18)
+        }
+    }
+    
+    func configureCell(_ setting: Setting) {
+        contentLabel.text = setting.title
+    }
+}

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableViewCell.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableViewCell.swift
@@ -9,9 +9,11 @@ import UIKit
 
 import SnapKit
 
-class SettingTableViewCell: UITableViewCell {
-
-    static let identifier = "SettingTableViewCell"
+class SettingTableViewCell: UITableViewCell, UITableViewRegisterable {
+    
+    // MARK: - Properties
+    
+    static var isFromNib = false
     
     // MARK: - UI Components
     

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableViewCell.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableViewCell.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-class SettingTableViewCell: UITableViewCell, UITableViewRegisterable {
+final class SettingTableViewCell: UITableViewCell, UITableViewRegisterable {
     
     // MARK: - Properties
     
@@ -30,6 +30,8 @@ class SettingTableViewCell: UITableViewCell, UITableViewRegisterable {
         return imageView
     }()
     
+    // MARK: - Life Cycles
+    
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
@@ -42,6 +44,8 @@ class SettingTableViewCell: UITableViewCell, UITableViewRegisterable {
         super.init(coder: coder)
     }
 }
+
+// MARK: - Extensions
 
 extension SettingTableViewCell {
     

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
@@ -16,6 +16,7 @@ class SettingViewController: UIViewController {
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.text = I18N.Setting.settingTitle
+        label.font = .PretendardRegular(size: 20)
         label.textAlignment = .left
         label.sizeToFit()
         return label
@@ -57,6 +58,7 @@ private extension SettingViewController {
     func setTableView() {
         tableView.register(SettingTableViewCell.self, forCellReuseIdentifier: SettingTableViewCell.identifier)
         tableView.rowHeight = 72
+        tableView.backgroundColor = .white
     }
     
     func setDelegate() {

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
@@ -1,0 +1,89 @@
+//
+//  SettingViewController.swift
+//  Umbba-iOS
+//
+//  Created by 남유진 on 2023/07/07.
+//
+
+import UIKit
+
+import SnapKit
+
+class SettingViewController: UIViewController {
+    
+    // MARK: - UI Components
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = I18N.Setting.settingTitle
+        label.textAlignment = .left
+        label.sizeToFit()
+        return label
+    }()
+    
+    private let tableView = UITableView(frame: .zero, style: .grouped)
+    private let dummy = Setting.dummy()
+    
+    // MARK: - Life Cycles
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setUI()
+        setLayout()
+        setTableView()
+        setDelegate()
+        setNavigationUI()
+    }
+}
+
+// MARK: - Extensions
+
+private extension SettingViewController {
+    
+    func setUI() {
+        view.backgroundColor = .white
+    }
+    
+    func setLayout() {
+        view.addSubview(tableView)
+        
+        tableView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaInsets)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+    }
+    
+    func setTableView() {
+        tableView.register(SettingTableViewCell.self, forCellReuseIdentifier: SettingTableViewCell.identifier)
+        tableView.rowHeight = 72
+    }
+    
+    func setDelegate() {
+        tableView.delegate = self
+        tableView.dataSource = self
+    }
+    
+    func setNavigationUI() {
+        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.PretendardRegular(size: 20), .foregroundColor: UIColor.UmbbaBlack]
+        navigationItem.leftBarButtonItem = UIBarButtonItem.init(customView: titleLabel)
+    }
+}
+
+extension SettingViewController: UITableViewDelegate { }
+
+extension SettingViewController: UITableViewDataSource {
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return dummy.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: SettingTableViewCell.identifier, for: indexPath) as? SettingTableViewCell else { return UITableViewCell() }
+
+        cell.configureCell(dummy[indexPath.row])
+        
+        return cell
+    }
+}

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
@@ -70,7 +70,16 @@ private extension SettingViewController {
     }
 }
 
-extension SettingViewController: UITableViewDelegate { }
+extension SettingViewController: UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let sectionHeaderView = SettingSectionHeaderView()
+        return sectionHeaderView
+    }
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return 72
+    }
+}
 
 extension SettingViewController: UITableViewDataSource {
     

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
@@ -33,6 +33,7 @@ class SettingViewController: UIViewController {
         setUI()
         setLayout()
         setTableView()
+        registerCell()
         setDelegate()
         setNavigationUI()
     }
@@ -56,9 +57,13 @@ private extension SettingViewController {
     }
     
     func setTableView() {
-        tableView.register(SettingTableViewCell.self, forCellReuseIdentifier: SettingTableViewCell.identifier)
         tableView.rowHeight = 72
         tableView.backgroundColor = .white
+    }
+    
+    func registerCell() {
+        SettingTableViewCell.register(target: tableView)
+        SettingSectionHeaderView.register(target: tableView)
     }
     
     func setDelegate() {
@@ -75,8 +80,8 @@ private extension SettingViewController {
 extension SettingViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let sectionHeaderView = SettingSectionHeaderView()
-        return sectionHeaderView
+        let header = SettingSectionHeaderView.dequeueReusableHeaderFooterView(tableView: tableView)
+        return header
     }
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return 72
@@ -90,11 +95,8 @@ extension SettingViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: SettingTableViewCell.identifier, for: indexPath) as? SettingTableViewCell else { return UITableViewCell() }
-
+        let cell = SettingTableViewCell.dequeueReusableCell(tableView: tableView, indexPath: indexPath)
         cell.configureCell(dummy[indexPath.row])
-        
         return cell
     }
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
@@ -82,9 +82,15 @@ extension SettingViewController: UITableViewDelegate {
         let header = SettingSectionHeaderView.dequeueReusableHeaderFooterView(tableView: tableView)
         return header
     }
+    
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return 72
     }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 72
+    }
+    
 }
 
 extension SettingViewController: UITableViewDataSource {

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-class SettingViewController: UIViewController {
+final class SettingViewController: UIViewController {
     
     // MARK: - UI Components
 
@@ -57,7 +57,6 @@ private extension SettingViewController {
     }
     
     func setTableView() {
-        tableView.rowHeight = 72
         tableView.backgroundColor = .white
     }
     


### PR DESCRIPTION
## 🔥*Pull requests*

🪵 **작업한 브랜치**
- feature/#14

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 테이블뷰 셀 구현
- 섹션헤더뷰 구현
- 네비게이션바 구현

**<참고사항>**
-알람 설정의 스위치는 아직 커스텀하지 않았습니다 디자인 확정되면 적용하겠습니다!
-셀에 있는 오른쪽 화살표는 SF symbols에서 찾아서 비슷한 형태로 넣어두었습니다 이것도 이미지 확정되면 적용하겠습니다!

**<리뷰 노트>**
-네비게이션바에 설정 글씨 왼쪽에 넣는 법
: 타이틀로 넣으면 자동으로 가운데 정렬이 되어서 item으로 넣어주었다.
```swift
func setNavigationUI() {
        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.font: UIFont.PretendardRegular(size: 20), .foregroundColor: UIColor.UmbbaBlack]
        navigationItem.leftBarButtonItem = UIBarButtonItem.init(customView: titleLabel)
}
```

-UITableViewRegiseterable 프로토콜을 채택하여 간략하게 cell을 register해주었다.
```swift
func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
        let header = SettingSectionHeaderView.dequeueReusableHeaderFooterView(tableView: tableView)
        return header
}
```

```swift
func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
        let cell = SettingTableViewCell.dequeueReusableCell(tableView: tableView, indexPath: indexPath)
        cell.configureCell(dummy[indexPath.row])
        return cell
}
```

📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|PNG|<img src = "https://github.com/Team-Umbba/Umbba-iOS/assets/55316673/fa5f9d42-4ef4-4025-80fe-0fe34f313515" width ="250">

📟 **관련 이슈**
- Resolved: #14 
