### PR TITLE
[Feat] #39 계정 관리 뷰 구현

### DIFF
--- a/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
+++ b/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
@@ -78,6 +78,7 @@ enum I18N {
         static let settingLabel = "알람 설정"
         static let userSectionLabel = ["계정 관리"]
         static let teamSectionLabel = ["About 엄빠도 어렸다", "이용약관", "공지사항"]
+        static let accountSectionLabel = ["로그아웃", "회원 탈퇴"]
     }
     
     enum Alert {

--- a/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
+++ b/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
@@ -76,6 +76,8 @@ enum I18N {
     enum Setting {
         static let settingTitle = "설정"
         static let settingLabel = "알람 설정"
+        static let settingNavigationTitle = "설정"
+        static let accountNavigationTitle = "계정 관리"
         static let userSectionLabel = ["계정 관리"]
         static let teamSectionLabel = ["About 엄빠도 어렸다", "이용약관", "공지사항"]
         static let accountSectionLabel = ["로그아웃", "회원 탈퇴"]

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/AccountTableView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/AccountTableView.swift
@@ -13,6 +13,13 @@ final class AccountTableView: UIView {
     
     // MARK: - UI Components
     
+    private let navigationBarView: CustomNavigationBar = {
+        let view = CustomNavigationBar()
+        view.pretendardTitle = I18N.Setting.accountNavigationTitle
+        view.isLeftButtonIncluded = true
+        return view
+    }()
+    
     lazy var tableView = UITableView(frame: .zero, style: .plain)
     
     // MARK: - Life Cycles
@@ -36,23 +43,29 @@ final class AccountTableView: UIView {
 private extension AccountTableView {
     
     func setUI() {
-        backgroundColor = .Gray400
+        backgroundColor = .UmbbaWhite
     }
-    
+
     func setLayout() {
-        addSubview(tableView)
+        addSubviews(navigationBarView, tableView)
+        
+        navigationBarView.snp.makeConstraints {
+             $0.top.equalTo(self.safeAreaLayoutGuide)
+             $0.leading.trailing.equalToSuperview()
+        }
         
         tableView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.top.equalTo(navigationBarView.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
         }
     }
     
     func setTableView() {
-        tableView.backgroundColor = .Gray400
+        tableView.backgroundColor = .UmbbaWhite
+        tableView.isScrollEnabled = false
     }
     
     func registerCell() {
         SettingTableViewCell.register(target: tableView)
     }
 }
-

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/AccountTableView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/AccountTableView.swift
@@ -5,4 +5,54 @@
 //  Created by 남유진 on 2023/07/11.
 //
 
-import Foundation
+import UIKit
+
+import SnapKit
+
+final class AccountTableView: UIView {
+    
+    // MARK: - UI Components
+    
+    lazy var tableView = UITableView(frame: .zero, style: .plain)
+    
+    // MARK: - Life Cycles
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setLayout()
+        setTableView()
+        registerCell()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Extensions
+
+private extension AccountTableView {
+    
+    func setUI() {
+        backgroundColor = .Gray400
+    }
+    
+    func setLayout() {
+        addSubview(tableView)
+        
+        tableView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    func setTableView() {
+        tableView.backgroundColor = .Gray400
+    }
+    
+    func registerCell() {
+        SettingTableViewCell.register(target: tableView)
+    }
+}
+

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingSectionHeaderView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingSectionHeaderView.swift
@@ -50,7 +50,7 @@ final class SettingSectionHeaderView: UITableViewHeaderFooterView, UITableViewHe
 private extension SettingSectionHeaderView {
     
     func setUI() {
-        contentView.backgroundColor = .white
+        contentView.backgroundColor = .UmbbaWhite
     }
     
     func setLayout() {

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableView.swift
@@ -13,6 +13,12 @@ final class SettingTableView: UIView {
     
     // MARK: - UI Components
     
+    private let navigationBarView: CustomNavigationBar = {
+        let view = CustomNavigationBar()
+        view.pretendardTitle = I18N.Setting.settingNavigationTitle
+        return view
+    }()
+    
     lazy var tableView = UITableView(frame: .zero, style: .plain)
     
     // MARK: - Life Cycles
@@ -36,19 +42,25 @@ final class SettingTableView: UIView {
 private extension SettingTableView {
     
     func setUI() {
-        backgroundColor = .white
+        backgroundColor = .UmbbaWhite
     }
     
     func setLayout() {
-        addSubview(tableView)
+        addSubviews(navigationBarView, tableView)
+        
+        navigationBarView.snp.makeConstraints {
+             $0.top.equalTo(self.safeAreaLayoutGuide)
+             $0.leading.trailing.equalToSuperview()
+        }
         
         tableView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.top.equalTo(navigationBarView.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
         }
     }
     
     func setTableView() {
-        tableView.backgroundColor = .white
+        tableView.backgroundColor = .UmbbaWhite
         tableView.sectionFooterHeight = 0
         tableView.sectionHeaderTopPadding = 1
         tableView.isScrollEnabled = false

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableViewCell.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableViewCell.swift
@@ -60,12 +60,12 @@ private extension SettingTableViewCell {
         
         contentLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.leading.equalToSuperview().offset(24)
+            $0.leading.equalToSuperview().inset(24)
         }
         
         buttonImage.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.trailing.equalToSuperview().offset(-24)
+            $0.trailing.equalToSuperview().inset(24)
             $0.size.equalTo(18)
         }
     }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableViewCell.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableViewCell.swift
@@ -50,7 +50,7 @@ final class SettingTableViewCell: UITableViewCell, UITableViewRegisterable {
 private extension SettingTableViewCell {
     
     func setUI() {
-        self.backgroundColor = .white
+        self.backgroundColor = .UmbbaWhite
         separatorInset.left = 0
         self.selectionStyle = .none
     }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableViewCell.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableViewCell.swift
@@ -24,7 +24,7 @@ final class SettingTableViewCell: UITableViewCell, UITableViewRegisterable {
         return label
     }()
     
-    private lazy var buttonImage: UIImageView = {
+    lazy var buttonImage: UIImageView = {
         let imageView = UIImageView()
         imageView.image = UIImage(systemName: "chevron.compact.right")?.withTintColor(.gray, renderingMode: .alwaysOriginal)
         return imageView

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/AccountViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/AccountViewController.swift
@@ -7,11 +7,48 @@
 
 import UIKit
 
-class AccountViewController: UIViewController {
+final class AccountViewController: UIViewController {
 
+    // MARK: - UI Components
+    
+    private let accountTableView = AccountTableView()
+    private lazy var accounttableView = accountTableView.tableView
+    private let accountSection = I18N.Setting.accountSectionLabel
+    
+    // MARK: - Life Cycles
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.view = accountTableView
+        
+        setDelegate()
+    }
+}
 
-        view.backgroundColor = .blue
+// MARK: - Extensions
+
+private extension AccountViewController {
+    
+    func setDelegate() {
+        accounttableView.delegate = self
+        accounttableView.dataSource = self
+    }
+}
+
+extension AccountViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 72
+    }
+}
+
+extension AccountViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return accountSection.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = SettingTableViewCell.dequeueReusableCell(tableView: tableView, indexPath: indexPath)
+        cell.contentLabel.text = I18N.Setting.accountSectionLabel[indexPath.row]
+        return cell
     }
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/AccountViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/AccountViewController.swift
@@ -49,6 +49,7 @@ extension AccountViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = SettingTableViewCell.dequeueReusableCell(tableView: tableView, indexPath: indexPath)
         cell.contentLabel.text = I18N.Setting.accountSectionLabel[indexPath.row]
+        cell.buttonImage.isHidden = true
         return cell
     }
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/AccountViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/AccountViewController.swift
@@ -17,9 +17,13 @@ final class AccountViewController: UIViewController {
     
     // MARK: - Life Cycles
     
+    override func loadView() {
+        super.loadView()
+        view = accountTableView
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view = accountTableView
         
         setDelegate()
     }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
@@ -20,10 +20,14 @@ final class SettingViewController: UIViewController {
 
     // MARK: - Life Cycles
     
+    override func loadView() {
+        super.loadView()
+        view = settingTableView
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view = settingTableView
-        
+
         setDelegate()
     }
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
@@ -95,7 +95,6 @@ extension SettingViewController: UITableViewDataSource {
             return teamSection.count
         default:
             return 0
-            
         }
     }
     
@@ -111,7 +110,6 @@ extension SettingViewController: UITableViewDataSource {
             return UITableViewCell()
             
         }
-        
         return cell
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

🪵 **작업한 브랜치**
- feature/#39

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 계정 관리 뷰 구현하기
- 설정 뷰 네비게이션바 추가
- 계정 관리 뷰 네비게이션바 추가
- .white 적용되었던 UI 전부 .UmbbaWhite로 변경
- 이전 코드리뷰 적용

**<참고사항>**
-아직 계정 관리 뷰 네비게이션바의 왼쪽 backbutton을 탭했을 때 액션은 넣지 않았습니다.

**<리뷰노트>**
-테이블뷰의 autolayout을 잡을 때에는 top만 잡아주는 것이 아니라 leading, trailing, bottom도 잡아줘야한다.
-계정 관리 뷰에서는 재사용셀에 버튼이미지가 없어서 hidden처리해주었다.
```swift
func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
        let cell = SettingTableViewCell.dequeueReusableCell(tableView: tableView, indexPath: indexPath)
        cell.contentLabel.text = I18N.Setting.accountSectionLabel[indexPath.row]
        cell.buttonImage.isHidden = true
        return cell
}
```


📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|IMG(계정 관리 뷰)|<img src = "https://github.com/Team-Umbba/Umbba-iOS/assets/55316673/21067efc-413d-473f-8ac0-6d6f1921989c" width ="250">|
|GIF|<img src = "https://github.com/Team-Umbba/Umbba-iOS/assets/55316673/e859fc29-c032-41ab-bd94-4374501666f3" width ="250">|

📟 **관련 이슈**
- Resolved: #39 