### PR TITLE
[Feat] #45 - 설정 테이블뷰셀 웹뷰 연결

### DIFF
--- a/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
+++ b/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
@@ -93,6 +93,8 @@ enum I18N {
         static let userSectionLabel = ["계정 관리"]
         static let teamSectionLabel = ["About 엄빠도 어렸다", "이용약관", "공지사항"]
         static let accountSectionLabel = ["로그아웃", "회원 탈퇴"]
+        static let termsOfUseURL = "https://www.notion.so/f1a14bf60ed4421f9b3761ef88906adb"
+        static let privacyProcessURL = "https://www.notion.so/99fe0f58825d4f87bd3b987fadc623b6 "
     }
     
     enum Alert {

--- a/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
+++ b/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
@@ -93,8 +93,9 @@ enum I18N {
         static let userSectionLabel = ["계정 관리"]
         static let teamSectionLabel = ["About 엄빠도 어렸다", "이용약관", "공지사항"]
         static let accountSectionLabel = ["로그아웃", "회원 탈퇴"]
-        static let termsOfUseURL = "https://www.notion.so/f1a14bf60ed4421f9b3761ef88906adb"
-        static let privacyProcessURL = "https://www.notion.so/99fe0f58825d4f87bd3b987fadc623b6 "
+        static let urlArray = ["https://www.notion.so/f1a14bf60ed4421f9b3761ef88906adb",
+                               "https://www.notion.so/99fe0f58825d4f87bd3b987fadc623b6",
+                               "https://www.notion.so/99fe0f58825d4f87bd3b987fadc623b6"]
     }
     
     enum Alert {

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/AccountTableView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/AccountTableView.swift
@@ -11,6 +11,10 @@ import SnapKit
 
 final class AccountTableView: UIView {
     
+    // MARK: - Properties
+
+    weak var navigationdelegate: NavigationBarDelegate?
+    
     // MARK: - UI Components
     
     private let navigationBarView: CustomNavigationBar = {
@@ -28,6 +32,7 @@ final class AccountTableView: UIView {
         super.init(frame: frame)
         
         setUI()
+        setAddTarget()
         setLayout()
         setTableView()
         registerCell()
@@ -44,6 +49,10 @@ private extension AccountTableView {
     
     func setUI() {
         backgroundColor = .UmbbaWhite
+    }
+    
+    func setAddTarget() {
+        navigationBarView.leftButton.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
     }
 
     func setLayout() {
@@ -63,9 +72,15 @@ private extension AccountTableView {
     func setTableView() {
         tableView.backgroundColor = .UmbbaWhite
         tableView.isScrollEnabled = false
+        tableView.separatorStyle = .none
     }
     
     func registerCell() {
         SettingTableViewCell.register(target: tableView)
+    }
+    
+    @objc
+    func backButtonTapped() {
+        navigationdelegate?.backButtonTapped()
     }
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingSectionHeaderView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingSectionHeaderView.swift
@@ -31,6 +31,12 @@ final class SettingSectionHeaderView: UITableViewHeaderFooterView, UITableViewHe
         return mySwitch
     }()
     
+    private let lineView: UIView = {
+        let line = UIView()
+        line.backgroundColor = .Gray400
+        return line
+    }()
+    
     // MARK: - Life Cycles
     
     override init(reuseIdentifier: String?) {
@@ -54,7 +60,7 @@ private extension SettingSectionHeaderView {
     }
     
     func setLayout() {
-        contentView.addSubviews(settingLabel, alarmSwitch)
+        contentView.addSubviews(settingLabel, alarmSwitch, lineView)
         
         settingLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
@@ -64,6 +70,11 @@ private extension SettingSectionHeaderView {
         alarmSwitch.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.trailing.equalToSuperview().inset(24)
+        }
+        
+        lineView.snp.makeConstraints {
+            $0.bottom.leading.trailing.equalToSuperview()
+            $0.height.equalTo(1)
         }
     }
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableView.swift
@@ -65,6 +65,7 @@ private extension SettingTableView {
         tableView.sectionHeaderTopPadding = 1
         tableView.isScrollEnabled = false
         tableView.isUserInteractionEnabled = true
+        tableView.separatorStyle = .none
     }
     
     func registerCell() {

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableViewCell.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/View/SettingTableViewCell.swift
@@ -30,6 +30,12 @@ final class SettingTableViewCell: UITableViewCell, UITableViewRegisterable {
         return imageView
     }()
     
+    private let lineView: UIView = {
+        let line = UIView()
+        line.backgroundColor = .Gray400
+        return line
+    }()
+    
     // MARK: - Life Cycles
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -56,7 +62,7 @@ private extension SettingTableViewCell {
     }
     
     func setLayout() {
-        contentView.addSubviews(contentLabel, buttonImage)
+        contentView.addSubviews(contentLabel, buttonImage, lineView)
         
         contentLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
@@ -67,6 +73,11 @@ private extension SettingTableViewCell {
             $0.centerY.equalToSuperview()
             $0.trailing.equalToSuperview().inset(24)
             $0.size.equalTo(18)
+        }
+        
+        lineView.snp.makeConstraints {
+            $0.bottom.leading.trailing.equalToSuperview()
+            $0.height.equalTo(1)
         }
     }
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/AccountViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/AccountViewController.swift
@@ -36,6 +36,7 @@ private extension AccountViewController {
     func setDelegate() {
         accounttableView.delegate = self
         accounttableView.dataSource = self
+        accountTableView.navigationdelegate = self
     }
 }
 
@@ -56,4 +57,15 @@ extension AccountViewController: UITableViewDataSource {
         cell.buttonImage.isHidden = true
         return cell
     }
+}
+
+extension AccountViewController: NavigationBarDelegate {
+    
+    func backButtonTapped() {
+        self.navigationController?.popViewController(animated: true)
+    }
+    
+    func completeButtonTapped() {
+    }
+    
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
@@ -74,8 +74,6 @@ extension SettingViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
-        
         switch indexPath.section {
         case 0:
             let accountViewController = AccountViewController()
@@ -106,6 +104,7 @@ extension SettingViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = SettingTableViewCell.dequeueReusableCell(tableView: tableView, indexPath: indexPath)
+        cell.selectionStyle = .none
         
         switch indexPath.section {
         case 0:

--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/SettingViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import SnapKit
+import SafariServices
 
 final class SettingViewController: UIViewController {
     
@@ -74,18 +75,19 @@ extension SettingViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
+        
         switch indexPath.section {
         case 0:
             let accountViewController = AccountViewController()
             self.navigationController?.pushViewController(accountViewController, animated: true)
         case 1:
-            if indexPath.row == 0 { print("--> \(indexPath.row)") }
-            if indexPath.row == 1 { print("--> \(indexPath.row)") }
-            if indexPath.row == 2 { print("--> \(indexPath.row)") }
+            if let url = URL(string: I18N.Setting.urlArray[indexPath.row]) {
+                let safariViewController = SFSafariViewController(url: url)
+                present(safariViewController, animated: true, completion: nil)
+            }
         default:
             return
         }
-        
     }
 }
 
@@ -112,7 +114,6 @@ extension SettingViewController: UITableViewDataSource {
             cell.contentLabel.text = I18N.Setting.teamSectionLabel[indexPath.row]
         default:
             return UITableViewCell()
-            
         }
         return cell
     }


### PR DESCRIPTION
## 🔥*Pull requests*

🪵 **작업한 브랜치**
- feature/#45

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 계정 관리뷰 네비게이션바 백버튼 액션 추가
- 웹뷰 url 배열 생성
- 설정뷰 section1의 cell에 웹뷰 연결
- 설정뷰 섹션 헤더뷰의 seperator 선이 뷰의 왼쪽에 달라붙지 않는 이슈 해결

**<참고사항>**
-section1 마지막 row의 링크는 임의로 넣어두었습니다. 링크가 생성되는대로 변경하겠습니다.
-스크린샷에서 개인 notion페이지여서 로그인 창으로 넘어가는 상황입니다.

**<리뷰노트>**
- TableView에서 기본적으로 제공되는 separator style이 default로 가지는 디자인이 있다. 고로 섹션 헤더에 들어가는 inset은 조정이 되지 않는다. 이를 해결하기 위해서는 section headerview에 밑줄을 UIView로 추가로 그려주고 공통적으로 셀 안에다가도 UIView를 이용해서 밑줄을 그려주는 방법을 사용한다.
```swift
private let lineView: UIView = {
    let line = UIView()
    line.backgroundColor = .Gray400
    return line
}()
```
```swift
lineView.snp.makeConstraints {
    $0.bottom.leading.trailing.equalToSuperview()
    $0.height.equalTo(1)
}
```
- 웹뷰 연결에 다양한 방법이 있는데 SFSafariView를 사용하였다. 이는 safari가 기본으로 제공하는 기능을 사용할 수 있다는 장점이 있다. 커스텀이 필요한 웹뷰가 아니라면 이를 사용해도 될 것 같다고 판단하였다.
- secion0은 웹뷰연결이 필요 없는 섹션이다. section1은 셀마다 연결되는 웹 url이 다르다. 따라서, 연결해야하는 url 링크를 배열로 선언해준 후 indexPath.row로 접근하였다.
```swift
func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
    tableView.deselectRow(at: indexPath, animated: true)
    
    switch indexPath.section {
    case 0:
        let accountViewController = AccountViewController()
        self.navigationController?.pushViewController(accountViewController, animated: true)
    case 1:
        if let url = URL(string: I18N.Setting.urlArray[indexPath.row]) {
            let safariViewController = SFSafariViewController(url: url)
            present(safariViewController, animated: true, completion: nil)
        }
    default:
        return
    }
}
```
📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/Team-Umbba/Umbba-iOS/assets/55316673/8eae5d13-f92b-4feb-a808-10faf325b76d" width="250">|

📟 **관련 이슈**
- Resolved: #45 
