### PR TITLE
[Feat] #56 - 초대하기 뷰 연결 및 플로우 구현

### DIFF
--- a/Umbba-iOS/Umbba-iOS/Global/Extension/String+.swift
+++ b/Umbba-iOS/Umbba-iOS/Global/Extension/String+.swift
@@ -37,4 +37,10 @@ extension String {
         guard self.range(of: pattern, options: .regularExpression) != nil else { return false }
         return true
     }
+    
+    func isValidInviteCode() -> Bool {
+        let pattern = "^[A-Z]{4}-[a-zA-Z0-9]{6}$"
+        guard self.range(of: pattern, options: .regularExpression) != nil else { return false }
+        return true
+    }
 }

--- a/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
+++ b/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
@@ -15,7 +15,7 @@ enum I18N {
     
     enum Onboarding {
         static let inviteNavigationTitle = "초대코드 입력"
-        static let inviteTitle = "초대코드를 입력해줘."
+        static let inviteTitle = "초대코드를 입력해줘"
         static let inviteBoldTitle = "초대코드"
         static let inviteTextFieldPlaceholder = "ex) ORWO-11yzwx"
         static let inviteError = "*올바른 초대코드 형식이 아닙니다"

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/View/EntryView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/View/EntryView.swift
@@ -9,11 +9,16 @@ import UIKit
 
 import SnapKit
 
+protocol EntryDelegate: AnyObject {
+    func entryButtonTapped()
+    func inviteButtonTapped()
+}
+
 final class EntryView: UIView {
     
     // MARK: - Properties
     
-    weak var nextDelegate: NextButtonDelegate?
+    weak var entryDelegate: EntryDelegate?
     
     // MARK: - UI Components
     
@@ -136,10 +141,16 @@ private extension EntryView {
 
     func setAddTarget() {
         entryButton.addTarget(self, action: #selector(entryButtonTapped), for: .touchUpInside)
+        inviteButton.addTarget(self, action: #selector(inviteButtonTapped), for: .touchUpInside)
     }
     
     @objc
     func entryButtonTapped() {
-        nextDelegate?.nextButtonTapped()
+        entryDelegate?.entryButtonTapped()
+    }
+    
+    @objc
+    func inviteButtonTapped() {
+        entryDelegate?.inviteButtonTapped()
     }
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/View/EntryView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/View/EntryView.swift
@@ -71,6 +71,7 @@ final class EntryView: UIView {
         button.setTitleColor(.Primary500, for: .normal)
         button.layer.borderColor = UIColor.Primary500.cgColor
         button.layer.borderWidth = 2
+        button.adjustsImageWhenHighlighted = false
         return button
     }()
     

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/View/EntryView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/View/EntryView.swift
@@ -65,14 +65,16 @@ final class EntryView: UIView {
         return label
     }()
     
-    private lazy var inviteButton: UIButton = {
-        let button = CustomButton(status: true, title: I18N.Auth.inviteButtonTitle)
-        button.setBackgroundColor(.UmbbaWhite, for: .normal)
-        button.setTitleColor(.Primary500, for: .normal)
-        button.layer.borderColor = UIColor.Primary500.cgColor
-        button.layer.borderWidth = 2
-        button.adjustsImageWhenHighlighted = false
-        return button
+    private lazy var inviteButton: CustomButton = {
+      let button = CustomButton(status: true, title: I18N.Auth.inviteButtonTitle)
+      button.setTitleColor(.Primary500, for: .normal)
+      button.layer.borderColor = UIColor.Primary500.cgColor
+      button.layer.borderWidth = 2
+        
+      var config = UIButton.Configuration.filled()
+      config.background.backgroundColor = .UmbbaWhite
+      button.configuration = config
+      return button
     }()
     
     override init(frame: CGRect) {

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/ViewController/EntryViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/ViewController/EntryViewController.swift
@@ -13,6 +13,7 @@ final class EntryViewController: UIViewController {
     
     override func loadView() {
         super.loadView()
+        
         self.view = entryView
     }
 
@@ -28,12 +29,16 @@ final class EntryViewController: UIViewController {
 
 extension EntryViewController {
     func setDelegate() {
-        entryView.nextDelegate = self
+        entryView.entryDelegate = self
     }
 }
 
-extension EntryViewController: NextButtonDelegate {
-    func nextButtonTapped() {
+extension EntryViewController: EntryDelegate {
+    func entryButtonTapped() {
         self.navigationController?.pushViewController(UserInfoViewController(), animated: true)
+    }
+    
+    func inviteButtonTapped() {
+        self.navigationController?.pushViewController(InviteViewController(), animated: true)
     }
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/InviteScene/InviteViewController/InviteViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/InviteScene/InviteViewController/InviteViewController.swift
@@ -63,7 +63,8 @@ extension InviteViewController: NavigationBarDelegate {
 
 extension InviteViewController: NextButtonDelegate {
     func nextButtonTapped() {
-        // FixMe: - 교신화면 만든 후 교신화면으로 이동
-        self.navigationController?.pushViewController(UserInfoViewController(), animated: true)
+        let userInfoViewController =  UserInfoViewController()
+        self.navigationController?.pushViewController(userInfoViewController, animated: true)
+        userInfoViewController.isReciever = true
     }
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/InviteScene/InviteViewController/InviteViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/InviteScene/InviteViewController/InviteViewController.swift
@@ -65,6 +65,6 @@ extension InviteViewController: NextButtonDelegate {
     func nextButtonTapped() {
         let userInfoViewController =  UserInfoViewController()
         self.navigationController?.pushViewController(userInfoViewController, animated: true)
-        userInfoViewController.isReciever = true
+        userInfoViewController.isReceiver = true
     }
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/InviteScene/View/InviteView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/InviteScene/View/InviteView.swift
@@ -134,10 +134,21 @@ private extension InviteView {
 
 extension InviteView: UITextFieldDelegate {
     func textFieldDidChangeSelection(_ textField: UITextField) {
-        self.nextButton.isEnabled = textField.hasText
         if !textField.hasText {
             self.errorLabel.isHidden = true
             inviteTextField.textFieldStatus = .normal
+        }
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        guard let inviteCode = inviteTextField.text else { return }
+        if !inviteCode.isValidInviteCode() {
+            self.errorLabel.isHidden = false
+            inviteTextField.textFieldStatus = .uncorrectedType
+        } else {
+            self.errorLabel.isHidden = true
+            inviteTextField.textFieldStatus = .normal
+            nextButton.isEnabled = true
         }
     }
     

--- a/Umbba-iOS/Umbba-iOS/Presentation/Common/TabBar/TabBarController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Common/TabBar/TabBarController.swift
@@ -97,14 +97,14 @@ private extension TabBarController {
     
     func setTabBar() {
         let home = makeTabBar(
-            viewController: NoticeAlarmViewController(),
+            viewController: ViewController(),
             title: "",
             tabBarImg: ImageLiterals.TabBar.icn_home,
             tabBarSelectedImg: ImageLiterals.TabBar.icn_home_selected,
             renderingMode: .alwaysOriginal
         )
         let list = makeTabBar(
-            viewController: ViewController(),
+            viewController: ArchivingViewController(),
             title: "",
             tabBarImg: ImageLiterals.TabBar.icn_list,
             tabBarSelectedImg: ImageLiterals.TabBar.icn_list_selected,

--- a/Umbba-iOS/Umbba-iOS/Presentation/Common/UIComponents/CustomButton.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Common/UIComponents/CustomButton.swift
@@ -51,7 +51,7 @@ private extension CustomButton {
         self.setBackgroundColor(.Gray400, for: .disabled)
         self.setTitle(title, for: .normal)
         self.setTitleColor(.white, for: .normal)
-        self.titleLabel?.font = .PretendardBold(size: 16)
+        self.titleLabel?.font = .PretendardSemiBold(size: 16)
         self.layer.cornerRadius = 30
     }
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/CompleteScene/ViewController/CompleteViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/CompleteScene/ViewController/CompleteViewController.swift
@@ -50,7 +50,6 @@ extension CompleteViewController: NavigationBarDelegate {
 
 extension CompleteViewController: NextButtonDelegate {
     func nextButtonTapped() {
-        // FixMe: - Main화면으로 이동
-        self.navigationController?.pushViewController(CompleteViewController(), animated: true)
+        self.navigationController?.pushViewController(TabBarController(), animated: true)
     }
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/FamilyInfoScene/View/FamilyInfoView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/FamilyInfoScene/View/FamilyInfoView.swift
@@ -77,7 +77,7 @@ final class FamilyInfoView: UIView {
         let button = UIButton()
         button.setBackgroundColor(.UmbbaWhite, for: .normal)
         button.setBackgroundColor(.Primary500, for: .selected)
-        button.setTitle(I18N.Onboarding.parent, for: .normal)
+        button.setTitle(I18N.Onboarding.child, for: .normal)
         button.setTitleColor(.UmbbaBlack, for: .normal)
         button.setTitleColor(.UmbbaWhite, for: .selected)
         button.titleLabel?.font = .PretendardRegular(size: 16)

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/View/UserInfoView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/View/UserInfoView.swift
@@ -112,6 +112,7 @@ final class UserInfoView: UIView {
         button.layer.borderColor = UIColor.Gray400.cgColor
         button.layer.borderWidth = 1
         button.layer.cornerRadius = 24
+        button.adjustsImageWhenHighlighted = false
         genderButton.append(button)
         return button
     }()
@@ -127,6 +128,7 @@ final class UserInfoView: UIView {
         button.layer.borderColor = UIColor.Gray400.cgColor
         button.layer.borderWidth = 1
         button.layer.cornerRadius = 24
+        button.adjustsImageWhenHighlighted = false
         genderButton.append(button)
         return button
     }()

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/ViewController/UserInfoViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/ViewController/UserInfoViewController.swift
@@ -55,7 +55,7 @@ extension UserInfoViewController: NavigationBarDelegate {
 extension UserInfoViewController: NextButtonDelegate {
     func nextButtonTapped() {
         if isReciever {
-            //FIXME: - 단답질문뷰로 이동
+            // FIX: - 단답질문뷰로 이동
             self.navigationController?.pushViewController(NoticeAlarmViewController(), animated: true)
         } else {
             self.navigationController?.pushViewController(FamilyInfoViewController(), animated: true)

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/ViewController/UserInfoViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/ViewController/UserInfoViewController.swift
@@ -11,7 +11,7 @@ final class UserInfoViewController: UIViewController {
     
     // MARK: - Properties
     
-    var isReciever: Bool = false
+    var isReceiver: Bool = false
     
     // MARK: - UI Components
     
@@ -54,7 +54,7 @@ extension UserInfoViewController: NavigationBarDelegate {
 
 extension UserInfoViewController: NextButtonDelegate {
     func nextButtonTapped() {
-        if isReciever {
+        if isReceiver {
             // FIX: - 단답질문뷰로 이동
             self.navigationController?.pushViewController(NoticeAlarmViewController(), animated: true)
         } else {

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/ViewController/UserInfoViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/UserInfoScene/ViewController/UserInfoViewController.swift
@@ -9,8 +9,13 @@ import UIKit
 
 final class UserInfoViewController: UIViewController {
     
+    // MARK: - Properties
+    
+    var isReciever: Bool = false
+    
     // MARK: - UI Components
     
+    private let inviteViewController = InviteViewController()
     private let userInfoView = UserInfoView()
     
     // MARK: - Life Cycles
@@ -49,6 +54,11 @@ extension UserInfoViewController: NavigationBarDelegate {
 
 extension UserInfoViewController: NextButtonDelegate {
     func nextButtonTapped() {
-        self.navigationController?.pushViewController(FamilyInfoViewController(), animated: true)
+        if isReciever {
+            //FIXME: - 단답질문뷰로 이동
+            self.navigationController?.pushViewController(NoticeAlarmViewController(), animated: true)
+        } else {
+            self.navigationController?.pushViewController(FamilyInfoViewController(), animated: true)
+        }
     }
 }


### PR DESCRIPTION
## 🔥*Pull requests*

🪵 **작업한 브랜치**
- feature/#56

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 시작하기 화면에서 초대코드 입력 시 초대코드 입력 뷰로 이동
- 초대코드 정규식 반영 (String+ 에 추가)
- 초대받는 측 온보딩 분기처리
- 버튼 클릭 시 회색으로 되지 않게 하는 속성 추가

🚨 **질문**
<!-- 질문할 사항이 있다면 적어주세요. -->
- 시작하기 화면의 시작하기 / 초대코드 입력 버튼 이벤트는 EntryDelegate를 만들어서 처리해주었습니다.
```swift
protocol EntryDelegate: AnyObject {
    func entryButtonTapped()
    func inviteButtonTapped()
}
```
- 초대코드의 정규식은 [대문자4자리]-[영어,숫자]6자리로 구성되어있어 다음과 같은 정규식을 통해 처리해주었습니다.
```swift
func isValidInviteCode() -> Bool {
    let pattern = "^[A-Z]{4}-[a-zA-Z0-9]{6}$"
    guard self.range(of: pattern, options: .regularExpression) != nil else { return false }
    return true
}
```
- 기존 코드에서는 에러코드 판별을 다음으로 버튼을 클릭하면 뜨게 해두었었는데 TextFieldEndEditing 부분에 정규식 판별을 통해 에러 구문을 띄우도록 해두었습니다.(에러일 경우 다음으로 버튼 비활성화)
- 초대받는측의 분기처리를 하기 위해 isReceiver라는 프로퍼티에 직접 접근하는 방식으로 구현했습니다.
- Button을 클릭하면 회색으로 변하는 이슈가 있어서 `button.adjustsImageWhenHighlighted = false` 이런 속성을 넣어줬는데,
이런 경고?가 뜹니다!! 도저히 다른 방법을 못찾겠어서 일단 이걸로 해두었는데 다른 방법이 있는지 궁금합니다 !!
```
'adjustsImageWhenHighlighted' was deprecated in iOS 15.0: This property is ignored when using UIButtonConfiguration, you may customize to replicate this behavior via a configurationUpdateHandler
```
- 현재 단답질문 뷰 작업 후에 주석 부분 수정할 예정입니다.

📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/Team-Umbba/Umbba-iOS/assets/75068759/2a746ee0-98e1-457d-a202-77dc103768b1" width ="250">|

📟 **관련 이슈**
- Resolved: #56
