### PR TITLE
[Feat] #67 - 문답화면 분기처리

### DIFF
--- a/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
+++ b/Umbba-iOS/Umbba-iOS.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		149099EB2A602EB0007242C6 /* WithdrawalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149099EA2A602EB0007242C6 /* WithdrawalView.swift */; };
 		149099ED2A603143007242C6 /* WithdrawalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149099EC2A603143007242C6 /* WithdrawalViewController.swift */; };
 		14A01D432A57D8A200D4F860 /* SettingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A01D422A57D8A200D4F860 /* SettingTableViewCell.swift */; };
+		14A0ACE82A62A50600C42097 /* BlurredLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A0ACE72A62A50600C42097 /* BlurredLabel.swift */; };
 		14A6D3062A5A63EF003A83B3 /* SettingSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A6D3052A5A63EF003A83B3 /* SettingSectionHeaderView.swift */; };
 		14AA29842A5685050038CDA1 /* NoticeAlarmViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14AA29832A5685050038CDA1 /* NoticeAlarmViewController.swift */; };
 		14AA29862A5685660038CDA1 /* NoticeAlarmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14AA29852A5685660038CDA1 /* NoticeAlarmView.swift */; };
@@ -136,6 +137,7 @@
 		149099EA2A602EB0007242C6 /* WithdrawalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalView.swift; sourceTree = "<group>"; };
 		149099EC2A603143007242C6 /* WithdrawalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalViewController.swift; sourceTree = "<group>"; };
 		14A01D422A57D8A200D4F860 /* SettingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTableViewCell.swift; sourceTree = "<group>"; };
+		14A0ACE72A62A50600C42097 /* BlurredLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurredLabel.swift; sourceTree = "<group>"; };
 		14A6D3052A5A63EF003A83B3 /* SettingSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingSectionHeaderView.swift; sourceTree = "<group>"; };
 		14AA29832A5685050038CDA1 /* NoticeAlarmViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeAlarmViewController.swift; sourceTree = "<group>"; };
 		14AA29852A5685660038CDA1 /* NoticeAlarmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeAlarmView.swift; sourceTree = "<group>"; };
@@ -510,6 +512,7 @@
 			children = (
 				6978158D2A5300F90047944C /* ButtonPress.swift */,
 				6978158F2A53015D0047944C /* MakeVibrate.swift */,
+				14A0ACE72A62A50600C42097 /* BlurredLabel.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1133,6 +1136,7 @@
 				697815772A52FF890047944C /* UITextField+.swift in Sources */,
 				149099E92A5FBDF6007242C6 /* AnswerDetailViewController.swift in Sources */,
 				A489BE062A5AFCE90027E817 /* ArchivingImageView.swift in Sources */,
+				14A0ACE82A62A50600C42097 /* BlurredLabel.swift in Sources */,
 				A42723C52A5A6C04003C445F /* ArchivingSectionCollectionViewCell.swift in Sources */,
 				14A01D432A57D8A200D4F860 /* SettingTableViewCell.swift in Sources */,
 				697815872A53003A0047944C /* UICollectionViewRegisterable.swift in Sources */,

--- a/Umbba-iOS/Umbba-iOS/Global/Utils/BlurredLabel.swift
+++ b/Umbba-iOS/Umbba-iOS/Global/Utils/BlurredLabel.swift
@@ -1,0 +1,69 @@
+//
+//  BlurredLabel.swift
+//  Umbba-iOS
+//
+//  Created by 남유진 on 2023/07/15.
+//
+
+import UIKit
+
+final class BlurLabel: UILabel {
+    var isBlurring = false {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+
+    var blurRadius: Double = 7.5 {
+        didSet {
+            blurFilter?.setValue(blurRadius, forKey: kCIInputRadiusKey)
+        }
+    }
+
+    lazy var blurFilter: CIFilter? = {
+        let blurFilter = CIFilter(name: "CIGaussianBlur")
+        blurFilter?.setDefaults()
+        blurFilter?.setValue(blurRadius, forKey: kCIInputRadiusKey)
+        return blurFilter
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        layer.isOpaque = false
+        layer.needsDisplayOnBoundsChange = true
+        layer.contentsScale = UIScreen.main.scale
+        layer.contentsGravity = .center
+        isOpaque = false
+        isUserInteractionEnabled = false
+        contentMode = .redraw
+    }
+
+    required init?(coder: NSCoder) {
+       fatalError("init(coder:) has not been implemented")
+        
+    }
+   
+   override func display(_ layer: CALayer) {
+       let bounds = layer.bounds
+       guard !bounds.isEmpty && bounds.size.width < CGFloat(UINT16_MAX) else {
+           layer.contents = nil
+           return
+       }
+       UIGraphicsBeginImageContextWithOptions(layer.bounds.size, layer.isOpaque, layer.contentsScale)
+       if let ctx = UIGraphicsGetCurrentContext() {
+           self.layer.draw(in: ctx)
+       
+           var image = UIGraphicsGetImageFromCurrentImageContext()?.cgImage
+           if isBlurring, let cgImage = image {
+               blurFilter?.setValue(CIImage(cgImage: cgImage), forKey: kCIInputImageKey)
+               let ciContext = CIContext(cgContext: ctx, options: nil)
+               if let blurOutputImage = blurFilter?.outputImage,
+                  let cgImage = ciContext.createCGImage(blurOutputImage, from: blurOutputImage.extent) {
+                   image = cgImage
+               }
+           }
+           layer.contents = image
+       }
+       UIGraphicsEndImageContext()
+   }
+}

--- a/Umbba-iOS/Umbba-iOS/Presentation/Home/DetailScene/View/AnswerDetailView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Home/DetailScene/View/AnswerDetailView.swift
@@ -18,6 +18,9 @@ final class AnswerDetailView: UIView {
     
     // MARK: - UI Components
     
+    private let isOpponentAnswer: Bool = true
+    private let isMyAnswer: Bool = false
+    
     private let navigationBarView: CustomNavigationBar = {
         let view = CustomNavigationBar()
         view.cafe24Title = I18N.Write.navigationTitle
@@ -56,6 +59,7 @@ final class AnswerDetailView: UIView {
         label.textColor = .UmbbaBlack
         label.text = I18N.Detail.partnerQuestLabel
         label.font = .PretendardSemiBold(size: 20)
+        label.numberOfLines = 0
         return label
     }()
     
@@ -68,11 +72,12 @@ final class AnswerDetailView: UIView {
         return answerView
     }()
     
-    private lazy var partnerAnswerContent: UILabel = {
-        let label = UILabel()
+    private lazy var partnerAnswerContent: BlurLabel = {
+        let label = BlurLabel()
         label.textColor = .Gray800
         label.text = I18N.Detail.noneAnswer
         label.font = .PretendardRegular(size: 16)
+        label.numberOfLines = 0
         return label
     }()
     
@@ -88,6 +93,7 @@ final class AnswerDetailView: UIView {
         let label = UILabel()
         label.text = I18N.Detail.myQuestLabel
         label.font = .PretendardSemiBold(size: 20)
+        label.numberOfLines = 0
         return label
     }()
     
@@ -113,6 +119,7 @@ final class AnswerDetailView: UIView {
         label.textColor = .Gray800
         label.text = I18N.Detail.pleaseAnswer
         label.font = .PretendardRegular(size: 16)
+        label.numberOfLines = 0
         return label
     }()
     
@@ -130,6 +137,7 @@ final class AnswerDetailView: UIView {
         setUI()
         setAddTarget()
         setLayout()
+        updateUI()
     }
     
     required init?(coder: NSCoder) {
@@ -166,8 +174,8 @@ private extension AnswerDetailView {
         }
         
         partnerQeustLabel.snp.makeConstraints {
-            $0.leading.equalToSuperview().inset(24)
-            $0.top.equalTo(themeStackView.snp.bottom).offset(50)
+            $0.trailing.leading.equalToSuperview().inset(24)
+            $0.top.equalTo(themeStackView.snp.bottom).offset(24)
         }
         
         partnerAnswerView.snp.makeConstraints {
@@ -181,12 +189,12 @@ private extension AnswerDetailView {
         }
         
         partnerAnswerContent.snp.makeConstraints {
-            $0.top.leading.equalToSuperview().inset(16)
+            $0.top.leading.trailing.equalToSuperview().inset(16)
         }
         
         myQuestLabel.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(24)
-            $0.top.equalTo(partnerAnswerView.snp.bottom).offset(41)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.top.equalTo(partnerAnswerView.snp.bottom).offset(32)
         }
         
         myAnswerView.snp.makeConstraints {
@@ -200,13 +208,19 @@ private extension AnswerDetailView {
         }
         
         myAnswerContent.snp.makeConstraints {
-            $0.top.trailing.equalToSuperview().inset(16)
+            $0.top.leading.trailing.equalToSuperview().inset(16)
         }
         
         nextButton.snp.makeConstraints {
             $0.bottom.equalTo(self.safeAreaLayoutGuide).offset(-12)
             $0.trailing.leading.equalToSuperview().inset(20)
             $0.height.equalTo(60)
+        }
+    }
+    
+    func updateUI() {
+        if isOpponentAnswer && !isMyAnswer {
+            partnerAnswerContent.isBlurring = true
         }
     }
     


### PR DESCRIPTION
## 🔥*Pull requests*

🪵 **작업한 브랜치**
- feature/#67

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
문답화면 분기처리

**<참고사항>**
-아래 레퍼런스를 참고하여 블러처리 구현했습니다.
https://stackoverflow.com/questions/64201384/why-does-uigraphicsgetcurrentcontext-return-nil-after-uigraphicsbeginimagecontex/

**<리뷰노트>**
-서버에서  isOpponentAnswer, isMyAnswer 값을 같이 주기때문에 `if isOpponentAnswer && !isMyAnswer`일 때 상대방 답변에 블러처리 하도록 했다.
-UIBlurEffect를 적용했을 때 결과는 아래와 같다. 그렇기 때문에 우리가 원하는 블러처리가 불가능하다고 판단했다.
<img src = "https://github.com/Team-Umbba/Umbba-iOS/assets/55316673/d86bc166-180c-4bb4-bd1d-fd0613637a6c" width ="180">


📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|PNG|<img src = "https://github.com/Team-Umbba/Umbba-iOS/assets/55316673/03f1fbab-12f1-4061-8059-fc55bfaf5113" width ="250">|

📟 **관련 이슈**
- Resolved: #67
