### PR TITLE
[Feat] #90 - 질문 확인하기 버튼 시 화면 전환 처리 

### DIFF
--- a/Umbba-iOS/Umbba-iOS/Presentation/Common/Alert/View/WriteCancelAlertView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Common/Alert/View/WriteCancelAlertView.swift
@@ -109,7 +109,7 @@ private extension WriteCancelAlertView {
         }
 
         buttonStackView.snp.makeConstraints {
-            $0.top.equalTo(alertTitle.snp.bottom).offset(24)
+            $0.bottom.equalToSuperview().inset(29)
             $0.leading.trailing.equalToSuperview().inset(32)
         }
     }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Home/DetailScene/ViewController/AnswerDetailViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Home/DetailScene/ViewController/AnswerDetailViewController.swift
@@ -39,7 +39,11 @@ extension AnswerDetailViewController {
 
 extension AnswerDetailViewController: NavigationBarDelegate {
     func backButtonTapped() {
-        self.navigationController?.popViewController(animated: true)
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let keyWindow = windowScene.windows.first else {
+            return
+        }
+        keyWindow.rootViewController = TabBarController()
     }
 
     func completeButtonTapped() {

--- a/Umbba-iOS/Umbba-iOS/Presentation/Home/MainScene/ViewController/MainViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Home/MainScene/ViewController/MainViewController.swift
@@ -47,8 +47,15 @@ private extension MainViewController {
 extension MainViewController: MainDelegate {
     func questionButtonTapped() {
         switch response_case {
-        case 1: // 답변 화면으로 이동
-            self.navigationController?.pushViewController(AnswerDetailViewController(), animated: true)
+        case 1:
+            guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                  let keyWindow = windowScene.windows.first else {
+                return
+            }
+            keyWindow.rootViewController = UINavigationController(rootViewController: AnswerDetailViewController())
+            if let navigationController = keyWindow.rootViewController as? UINavigationController {
+                navigationController.isNavigationBarHidden = true
+            }
         case 2:
             self.makeAlert(alertType: .inviteAlert) {}
         case 3:


### PR DESCRIPTION
## 🔥*Pull requests*

🪵 **작업한 브랜치**
- feature/#90

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 질문 확인하기 탭하면 rootViewController을 AnswerDetailViewController로 변경
- AnswerDetail뷰 네비게이션바 백버튼 누르면 rootViewController을 TabBarController로 변경

🚨 **질문**
<!-- 질문할 사항이 있다면 적어주세요. -->
- rootViewController를 직접 바꾸는 방식으로 구현했는데 이게 좋은 방법인지 의문이 듭니다. 
혹시 더 좋은 방법이 있다면 알려주시면 감사하겠습니다!

```swift
func backButtonTapped() {
    guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
               let keyWindow = windowScene.windows.first else {
           return
    }
    keyWindow.rootViewController = TabBarController()
}
```

📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/Team-Umbba/Umbba-iOS/assets/55316673/f111542d-3b8b-4315-816d-dbaf4dd059ab" width ="250">|

📟 **관련 이슈**
- Resolved: #90
