### PR TITLE
[Feat] #97 - 온보딩 완료 화면 애니메이션 구현 및 화면 전환 분기 처리 추가

### DIFF
--- a/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
+++ b/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
@@ -50,6 +50,7 @@ enum I18N {
         static let completeTitle = "과거에 도착했어!\n앞으로 나눌 이야기가 많을 거야"
         static let animationLabel = "오래된 공중전화에서 수신음이 들린다"
         static let callingButton = "전화 받기"
+        static let completeButton = "시작하기"
     }
     
     enum Auth {

--- a/Umbba-iOS/Umbba-iOS/Global/Resources/Assets.xcassets/back.imageset/Contents.json
+++ b/Umbba-iOS/Umbba-iOS/Global/Resources/Assets.xcassets/back.imageset/Contents.json
@@ -19,5 +19,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/ViewController/EntryViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/EntryScene/ViewController/EntryViewController.swift
@@ -35,7 +35,7 @@ extension EntryViewController {
 
 extension EntryViewController: EntryDelegate {
     func entryButtonTapped() {
-        self.navigationController?.pushViewController(UserInfoViewController(), animated: true)
+        self.navigationController?.pushViewController(AnimationViewController(), animated: true)
     }
     
     func inviteButtonTapped() {

--- a/Umbba-iOS/Umbba-iOS/Presentation/Auth/InviteScene/InviteViewController/InviteViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Auth/InviteScene/InviteViewController/InviteViewController.swift
@@ -63,8 +63,8 @@ extension InviteViewController: NavigationBarDelegate {
 
 extension InviteViewController: NextButtonDelegate {
     func nextButtonTapped() {
-        let userInfoViewController =  UserInfoViewController()
-        self.navigationController?.pushViewController(userInfoViewController, animated: true)
-        userInfoViewController.isReceiver = true
+        let animationViewController =  AnimationViewController()
+        self.navigationController?.pushViewController(animationViewController, animated: true)
+        animationViewController.isReceiver = true
     }
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/AnimationScene/ViewController/AnimationViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/AnimationScene/ViewController/AnimationViewController.swift
@@ -7,8 +7,12 @@
 
 import UIKit
 
-class AnimationViewController: UIViewController {
+final class AnimationViewController: UIViewController {
 
+    // MARK: - Properties
+    
+    var isReceiver: Bool = false
+    
     // MARK: - UI Components
     
     private let animationView = AnimationView()
@@ -38,6 +42,8 @@ extension AnimationViewController {
 
 extension AnimationViewController: NextButtonDelegate {
     func nextButtonTapped() {
-        self.navigationController?.pushViewController(UserInfoViewController(), animated: true)
+        let userInfoViewController =  UserInfoViewController()
+        self.navigationController?.pushViewController(userInfoViewController, animated: true)
+        userInfoViewController.isReceiver = true
     }
 }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/CompleteScene/View/CompleteView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/CompleteScene/View/CompleteView.swift
@@ -18,23 +18,31 @@ final class CompleteView: UIView {
     
     // MARK: - UI Components
     
-    private let navigationBarView: CustomNavigationBar = {
+    let navigationBarView: CustomNavigationBar = {
         let view = CustomNavigationBar()
         view.isLeftButtonIncluded = true
+        view.leftButton.tintColor = .white
+        view.backgroundColor = .clear
         return view
     }()
     
-    private let completeTitleLabel: UILabel = {
+    let backgroundImageView: UIImageView = {
+        let animationImage = UIImageView()
+        animationImage.image = ImageLiterals.Onboarding.img_depart
+        return animationImage
+    }()
+    
+    let completeTitleLabel: UILabel = {
         let label = UILabel()
         label.text = I18N.Onboarding.completeTitle
-        label.textColor = .UmbbaBlack
+        label.textColor = .UmbbaWhite
         label.font = .PretendardSemiBold(size: 24)
         label.numberOfLines = 2
         return label
     }()
     
     lazy var nextButton: CustomButton = {
-        let button = CustomButton(status: true, title: I18N.Common.nextButtonTitle)
+        let button = CustomButton(status: true, title: I18N.Onboarding.completeButton)
         button.isEnabled = true
         return button
     }()
@@ -67,7 +75,11 @@ private extension CompleteView {
     }
     
     func setLayout() {
-        self.addSubviews(navigationBarView, completeTitleLabel, nextButton)
+        self.addSubviews(backgroundImageView, navigationBarView, completeTitleLabel, nextButton)
+        
+        backgroundImageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
         
         navigationBarView.snp.makeConstraints {
             $0.top.equalTo(self.safeAreaLayoutGuide)
@@ -87,7 +99,7 @@ private extension CompleteView {
     }
     
     // MARK: - @objc Functions
-
+    
     @objc
     func backButtonTapped() {
         navigationdelegate?.backButtonTapped()

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/CompleteScene/ViewController/CompleteViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/CompleteScene/ViewController/CompleteViewController.swift
@@ -12,6 +12,7 @@ final class CompleteViewController: UIViewController {
     // MARK: - UI Components
     
     private let completeView = CompleteView()
+    //    private let imageView = completeView.backgroundImageView
     
     // MARK: - Life Cycles
     
@@ -24,6 +25,12 @@ final class CompleteViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+            guard let self = self else { return }
+            UIView.transition(with: self.completeView, duration: 1.0, options: .transitionCrossDissolve, animations: {
+                self.updateUI()
+            }, completion: nil)
+        }
         setDelegate()
     }
 }
@@ -31,10 +38,16 @@ final class CompleteViewController: UIViewController {
 // MARK: - Extensions
 
 private extension CompleteViewController {
-
+    
     func setDelegate() {
         completeView.navigationdelegate = self
         completeView.nextDelegate = self
+    }
+    
+    func updateUI() {
+        self.completeView.backgroundImageView.image = ImageLiterals.Onboarding.img_arrive
+        self.completeView.completeTitleLabel.textColor = .UmbbaBlack
+        self.completeView.navigationBarView.leftButton.tintColor = .UmbbaBlack
     }
 }
 
@@ -44,7 +57,7 @@ extension CompleteViewController: NavigationBarDelegate {
     }
     
     func completeButtonTapped() {
-
+        
     }
 }
 


### PR DESCRIPTION
## 🔥*Pull requests*

🪵 **작업한 브랜치**
- feature/#97

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 온보딩 완료 애니메이션 구현 (2초후에 다른 이미지로 변경되는)
- 교신화면 완료되어서 초대하기 측 분기처리하여 화면전환 구현해두었습니다.

🚨 **질문**
<!-- 질문할 사항이 있다면 적어주세요. -->

📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/Team-Umbba/Umbba-iOS/assets/75068759/9af1d67b-43cb-4099-94ea-abd04df28023" width ="250">|

📟 **관련 이슈**
- Resolved: #97
