### PR TITLE
[Chore] #185 - 초대코드 공유 메세지 변경, 푸시알림 클릭시 특정 뷰 이동 및 오류 수정

### DIFF
--- a/Umbba-iOS/Umbba-iOS/Application/AppDelegate.swift
+++ b/Umbba-iOS/Umbba-iOS/Application/AppDelegate.swift
@@ -20,9 +20,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         KakaoSDK.initSDK(appKey: "6bd3a68776c41b2f780a6ff2e4306101")
         FirebaseApp.configure()
-
+        
         application.registerForRemoteNotifications()
         Messaging.messaging().delegate = self
+        UNUserNotificationCenter.current().delegate = self
         
         return true
     }
@@ -50,9 +51,28 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         Messaging.messaging().apnsToken = deviceToken
     }
     
-    // Foreground(앱 켜진 상태)에서도 알림 오는 설정
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        completionHandler([.list, .banner])
+        completionHandler([.list, .banner, .badge])
+    }
+    
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        
+        let applicationState = UIApplication.shared.applicationState
+        if applicationState == .active || applicationState == .inactive {
+            guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                  let keyWindow = windowScene.windows.first else {
+                return
+            }
+            let answerDetailController = AnswerDetailViewController()
+            answerDetailController.isHome = true
+            keyWindow.rootViewController = UINavigationController(rootViewController: answerDetailController)
+            if let navigationController = keyWindow.rootViewController as? UINavigationController {
+                navigationController.isNavigationBarHidden = true
+            }
+            
+        }
+        
+        completionHandler()
     }
 }
 

--- a/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
+++ b/Umbba-iOS/Umbba-iOS/Global/Literals/StringLiterals.swift
@@ -87,6 +87,7 @@ enum I18N {
         static let questionTitle = "당신과 어머니의 꿈은 달라?\n당신과 어머니의 꿈으 ㄴ다라다라라라"
         static let answerPlaceholder = "답변을 입력해주세요"
         static let countText = "(0/100)"
+        static let saveButtonTitle = "저장하기"
     }
     
     enum Detail {

--- a/Umbba-iOS/Umbba-iOS/Presentation/Home/MainScene/ViewController/MainViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Home/MainScene/ViewController/MainViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 import KakaoSDKCommon
 import KakaoSDKTemplate
 import KakaoSDKShare
+import FirebaseDynamicLinks
 
 final class MainViewController: UIViewController {
     
@@ -45,7 +46,7 @@ final class MainViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         setDelegate()
         getCaseAPI()
         getMainAPI()
@@ -85,7 +86,7 @@ private extension MainViewController {
             guard let inviteUsername = caseEntity?.inviteUsername else { return }
             guard let installURL = caseEntity?.installURL else { return }
             self.makeAlert(inviteCode: inviteCode, inviteUsername: inviteUsername, installURL: installURL) {
-                self.kakao()
+                self.share()
             }
         case 3:
             self.makeAlert(alertType: .disconnectAlert) {}
@@ -94,54 +95,29 @@ private extension MainViewController {
         }
     }
     
-    func kakao() {
-        let feedTemplateJsonStringData =
-            """
-            {
-                "object_type": "feed",
-                "content": {
-                    "title": "'\(inviteUserName)'으로부터 초대가 왔어요.\\n초대 코드 : \(inviteCode) ",
-                    "description": "과거로 떠나 함께 추억을 나누고,\\n공감대를 형성해보세요.",
-                    "image_url": "https://github.com/Team-Umbba/Umbba-iOS/assets/75068759/64ba7265-9148-4f06-8235-de5f4030e92f",
-                    "link": {
-                        "mobile_web_url": "https://developers.kakao.com",
-                        "web_url": "https://developers.kakao.com"
-                    }
-                },
-                "buttons": [
-                    {
-                        "title": "초대 받기",
-                        "link": {
-                            "android_execution_params": "key1=value1&key2=value2",
-                            "ios_execution_params": "key1=value1&key2=value2"
-                        }
-                    }
-                ]
-            }
-            """.data(using: .utf8)!
+    func share() {
+        guard let inviteCode = inviteCode.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return }
         
-        if let templateJsonObject = SdkUtils.toJsonObject(feedTemplateJsonStringData) {
-            if ShareApi.isKakaoTalkSharingAvailable() {
-                ShareApi.shared.shareDefault(templateObject: templateJsonObject) {(linkResult, error) in
-                    if let error = error {
-                        print("error : \(error)")
-                    } else {
-                        print("defaultLink(templateObject:templateJsonObject) success.")
-                        guard let linkResult = linkResult else { return }
-                        UIApplication.shared.open(linkResult.url, options: [:], completionHandler: nil)
-                    }
-                }
-            } else {
-                let url = "itms-apps://itunes.apple.com/app/362057947"
-                if let url = URL(string: url), UIApplication.shared.canOpenURL(url) {
-                    if #available(iOS 10.0, *) {
-                        UIApplication.shared.open(url, options: [:], completionHandler: nil)
-                    } else {
-                        UIApplication.shared.openURL(url)
-                    }
-                }
+        guard let link = URL(string: "https://umbba.page.link/umbba?code=" + inviteCode) else { return }
+        let dynamicLinkComponents = DynamicLinkComponents(link: link, domainURIPrefix: "https://umbba.page.link/umbba")
+        
+        guard let longDynamic = dynamicLinkComponents?.url else { return }
+        let inviteText = "'\(inviteUserName)' 으로부터 초대가 왔어요💌\n\n당신의 가장 오래된 기억이 무엇인가요?\n과거로 떠나 함께 추억을 나누고, 공감대를 형성해보세요.\n\n어플 설치 후 하단의 초대코드를 입력해, 상대방과 연결하세요\n\n초대코드 : \(inviteCode)\n\n\(link)"
+        
+        let activityVC = UIActivityViewController(activityItems: [inviteText], applicationActivities: nil)
+        activityVC.excludedActivityTypes = [UIActivity.ActivityType.airDrop, UIActivity.ActivityType.mail, UIActivity.ActivityType.postToFacebook]
+        
+        activityVC.completionWithItemsHandler = { [weak self] (activityType, completed, _, error) in
+            if completed {
+                print("초대코드 공유 완료")
             }
+            if let error = error {
+                print("초대코드 공유 오류: \(error.localizedDescription)")
+            }
+            self?.dismiss(animated: true, completion: nil)
         }
+        
+        present(activityVC, animated: true, completion: nil)
     }
 }
 

--- a/Umbba-iOS/Umbba-iOS/Presentation/Home/MainScene/ViewController/MainViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Home/MainScene/ViewController/MainViewController.swift
@@ -12,6 +12,11 @@ import KakaoSDKTemplate
 import KakaoSDKShare
 import FirebaseDynamicLinks
 
+protocol PopUpDelegate: AnyObject {
+    func showInvitePopUP(inviteCode: String)
+    func showDisconnectPopUP()
+}
+
 final class MainViewController: UIViewController {
     
     // MARK: - Properties
@@ -30,9 +35,12 @@ final class MainViewController: UIViewController {
     var inviteCode: String = ""
     var inviteUserName: String = ""
     
+    weak var delegate: PopUpDelegate?
+    
     // MARK: - UI Components
     
     private let mainView = MainView()
+    //    private let tabBar = TabBarController()
     
     override func loadView() {
         super.loadView()
@@ -85,40 +93,39 @@ private extension MainViewController {
             guard let inviteCode = caseEntity?.inviteCode  else { return }
             guard let inviteUsername = caseEntity?.inviteUsername else { return }
             guard let installURL = caseEntity?.installURL else { return }
-            self.makeAlert(inviteCode: inviteCode, inviteUsername: inviteUsername, installURL: installURL) {
-                self.share()
-            }
+            NotificationCenter.default.post(name: Notification.Name("share"), object: nil, userInfo: ["inviteCode": inviteCode, "inviteUserName": inviteUsername, "installURL": installURL])
         case 3:
-            self.makeAlert(alertType: .disconnectAlert) {}
+            print("!!!!!")
+            NotificationCenter.default.post(name: Notification.Name("disconnect"), object: nil, userInfo: nil)
         default:
             break
         }
     }
     
-    func share() {
-        guard let inviteCode = inviteCode.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return }
-        
-        guard let link = URL(string: "https://umbba.page.link/umbba?code=" + inviteCode) else { return }
-        let dynamicLinkComponents = DynamicLinkComponents(link: link, domainURIPrefix: "https://umbba.page.link/umbba")
-        
-        guard let longDynamic = dynamicLinkComponents?.url else { return }
-        let inviteText = "'\(inviteUserName)' 으로부터 초대가 왔어요💌\n\n당신의 가장 오래된 기억이 무엇인가요?\n과거로 떠나 함께 추억을 나누고, 공감대를 형성해보세요.\n\n어플 설치 후 하단의 초대코드를 입력해, 상대방과 연결하세요\n\n초대코드 : \(inviteCode)\n\n\(link)"
-        
-        let activityVC = UIActivityViewController(activityItems: [inviteText], applicationActivities: nil)
-        activityVC.excludedActivityTypes = [UIActivity.ActivityType.airDrop, UIActivity.ActivityType.mail, UIActivity.ActivityType.postToFacebook]
-        
-        activityVC.completionWithItemsHandler = { [weak self] (activityType, completed, _, error) in
-            if completed {
-                print("초대코드 공유 완료")
-            }
-            if let error = error {
-                print("초대코드 공유 오류: \(error.localizedDescription)")
-            }
-            self?.dismiss(animated: true, completion: nil)
-        }
-        
-        present(activityVC, animated: true, completion: nil)
-    }
+//    func share() {
+//        guard let inviteCode = inviteCode.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return }
+//        
+//        guard let link = URL(string: "https://umbba.page.link/umbba?code=" + inviteCode) else { return }
+//        let dynamicLinkComponents = DynamicLinkComponents(link: link, domainURIPrefix: "https://umbba.page.link/umbba")
+//        
+//        guard let longDynamic = dynamicLinkComponents?.url else { return }
+//        let inviteText = "'\(inviteUserName)' 으로부터 초대가 왔어요💌\n\n당신의 가장 오래된 기억이 무엇인가요?\n과거로 떠나 함께 추억을 나누고, 공감대를 형성해보세요.\n\n어플 설치 후 하단의 초대코드를 입력해, 상대방과 연결하세요\n\n초대코드 : \(inviteCode)\n\n\(link)"
+//        
+//        let activityVC = UIActivityViewController(activityItems: [inviteText], applicationActivities: nil)
+//        activityVC.excludedActivityTypes = [UIActivity.ActivityType.airDrop, UIActivity.ActivityType.message, UIActivity.ActivityType.mail, UIActivity.ActivityType.postToFacebook]
+//        
+//        activityVC.completionWithItemsHandler = { [weak self] (activityType, completed, _, error) in
+//            if completed {
+//                print("초대코드 공유 완료")
+//            }
+//            if let error = error {
+//                print("초대코드 공유 오류: \(error.localizedDescription)")
+//            }
+//            self?.dismiss(animated: true, completion: nil)
+//        }
+//        
+//        present(activityVC, animated: true, completion: nil)
+//    }
 }
 
 extension MainViewController: MainDelegate {

--- a/Umbba-iOS/Umbba-iOS/Presentation/Home/WriteScene/View/AnswerWriteView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Home/WriteScene/View/AnswerWriteView.swift
@@ -29,7 +29,6 @@ final class AnswerWriteView: UIView {
         let view = CustomNavigationBar()
         view.cafe24Title = I18N.Write.navigationTitle
         view.isTitleViewIncluded = true
-        view.isRightButtonIncluded = true
         view.isLeftButtonIncluded = true
         return view
     }()
@@ -95,6 +94,12 @@ final class AnswerWriteView: UIView {
         return label
     }()
     
+    private lazy var saveButton: CustomButton = {
+        let button = CustomButton(status: false, title: I18N.Write.saveButtonTitle)
+        button.isEnabled = false
+        return button
+    }()
+    
     // MARK: - Life Cycles
     
     override init(frame: CGRect) {
@@ -117,11 +122,12 @@ final class AnswerWriteView: UIView {
 private extension AnswerWriteView {
     func setUI() {
         self.backgroundColor = .UmbbaWhite
+        self.addToolBar(textView: answerTextView)
     }
     
     func setAddTarget() {
         navigationBarView.leftButton.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
-        navigationBarView.rightButton.addTarget(self, action: #selector(completeButtonTapped), for: .touchUpInside)
+        saveButton.addTarget(self, action: #selector(completeButtonTapped), for: .touchUpInside)
     }
     
     func setDelegate() {
@@ -129,7 +135,7 @@ private extension AnswerWriteView {
     }
     
     func setLayout() {
-        self.addSubviews(navigationBarView, themeStackView, questionLabel, answerView)
+        self.addSubviews(navigationBarView, themeStackView, questionLabel, answerView, saveButton)
         answerView.addSubviews(answerTextView, countLabel)
         
         navigationBarView.snp.makeConstraints {
@@ -160,6 +166,12 @@ private extension AnswerWriteView {
         
         countLabel.snp.makeConstraints {
             $0.bottom.trailing.equalToSuperview().inset(16)
+        }
+        
+        saveButton.snp.makeConstraints {
+            $0.bottom.equalTo(self.safeAreaLayoutGuide).offset(-12)
+            $0.trailing.leading.equalToSuperview().inset(20)
+            $0.height.equalTo(60)
         }
     }
     
@@ -209,6 +221,7 @@ extension AnswerWriteView: UITextViewDelegate {
         if textView.text.isEmpty {
             textView.text = I18N.Write.answerPlaceholder
             textView.textColor = .Gray800
+            saveButton.isEnabled = false
         }
     }
     
@@ -225,6 +238,7 @@ extension AnswerWriteView: UITextViewDelegate {
         checkMaxLength(textView)
         let count = textView.text.count
         countLabel.text = "(\(count)/100)"
+        saveButton.isEnabled = count > 0 ? true : false
     }
     
     func textViewShouldEndEditing(_ textView: UITextView) -> Bool {

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/QuestScene/View/QuestView.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/QuestScene/View/QuestView.swift
@@ -47,7 +47,7 @@ final class QuestView: UIView {
         let view = UIProgressView()
         view.trackTintColor = .Gray400
         view.progressTintColor = .Primary600
-        view.progress = 0.2
+        view.progress = 0.0
         return view
     }()
     

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/QuestScene/ViewController/QuestViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/QuestScene/ViewController/QuestViewController.swift
@@ -100,7 +100,7 @@ extension QuestViewController: NavigationBarDelegate {
         if currentIndexPath.item == 0 {
             self.navigationController?.popViewController(animated: true)
         } else {
-            progressView.progress = Float(currentIndexPath.item) * 0.2
+            progressView.progress = Float(currentIndexPath.item - 1) * 0.2
             let previousIndexPath = IndexPath(item: currentIndexPath.item - 1, section: currentIndexPath.section)
             questCollectionView.scrollToItem(at: previousIndexPath, at: .centeredHorizontally, animated: true)
             let index = currentIndexPath.item - 1
@@ -125,14 +125,17 @@ extension QuestViewController: NextButtonDelegate {
                 self.patchReceiveAPI(user_info: UserData.shared.userInfo,
                                      onboarding_answer_list: UserData.shared.onboardingAnswerList)
             } else {
-                let pushAlarmViewController = PushAlarmViewController()
-                pushAlarmViewController.isReceiver = self.isReceiver
-                self.navigationController?.pushViewController(pushAlarmViewController, animated: true)
+                progressView.progress = Float(currentIndexPath.item + 1) * 0.2
+                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.2) {
+                    let pushAlarmViewController = PushAlarmViewController()
+                    pushAlarmViewController.isReceiver = self.isReceiver
+                    self.navigationController?.pushViewController(pushAlarmViewController, animated: true)
+                }
             }
         } else {
             let index = currentIndexPath.item
             hasAnswer(index + 1)
-            progressView.progress = Float(currentIndexPath.item + 2) * 0.2
+            progressView.progress = Float(currentIndexPath.item + 1) * 0.2
             let nextIndexPath = IndexPath(item: currentIndexPath.item + 1, section: currentIndexPath.section)
             questCollectionView.scrollToItem(at: nextIndexPath, at: .centeredHorizontally, animated: true)
         }

--- a/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/QuestScene/ViewController/QuestViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Onboarding/QuestScene/ViewController/QuestViewController.swift
@@ -48,6 +48,12 @@ final class QuestViewController: UIViewController {
         setDelegate()
         registerCell()
     }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        progressView.progress = 0.8
+    }
 }
 
 // MARK: - Extensions
@@ -190,10 +196,14 @@ extension QuestViewController {
             switch NetworkResult {
             case .success(let data):
                 if let data = data as? GenericResponse<ReceiveEntity> {
-                    let noticeAlarmViewController = NoticeAlarmViewController()
-                    noticeAlarmViewController.isReceiver = self.isReceiver
-                    noticeAlarmViewController.pushTime = data.data?.pushTime ?? ""
-                    self.navigationController?.pushViewController(noticeAlarmViewController, animated: true)
+                    guard let currentIndexPath = self.questCollectionView.indexPathsForVisibleItems.first else { return }
+                    self.progressView.progress = Float(currentIndexPath.item + 1) * 0.2
+                    DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.2) {
+                        let noticeAlarmViewController = NoticeAlarmViewController()
+                        noticeAlarmViewController.isReceiver = self.isReceiver
+                        noticeAlarmViewController.pushTime = data.data?.pushTime ?? ""
+                        self.navigationController?.pushViewController(noticeAlarmViewController, animated: true)
+                    }
                 }
             case .requestErr, .serverErr:
                 self.makeAlert(title: "오류가 발생했습니다", message: "다시 시도해주세요")


### PR DESCRIPTION
## 🔥*Pull requests*

🪵 **작업한 브랜치**
- feature/#185

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- ProgressBar UT 사항 반영 (기존 0.2부터 시작 -> 0.0부터 시작, 마지막 5번째 질문에서 뷰 넘어갈때 다 차고 넘어가게 구현)
- 시간설정, 시간공지 뷰에서 BackButton 누를시에 ProgressBar 0.8로 설정
- 답변화면 UT사항 반영 (답변 작성 저장 버튼 추가, Navigtaion의 작성완료 버튼 삭제)
- 초대코드 카카오톡 공유에서 Share기능으로 변경
- PopUp뷰가 MainViewController위로 띄워져서 TabBar가 클릭되는 이슈가 있어서 TabBar위에 alert창의 띄우도록 수정
- 푸시알림 클릭시 답변뷰로 이동

🚨 **질문**
<!-- 질문할 사항이 있다면 적어주세요. -->

📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|답변작성뷰|<img src = "https://github.com/Team-Umbba/Umbba-iOS/assets/75068759/7c053313-3709-481b-b235-79ed97f6c997" width ="250">|
|초대팝업|<img src = "https://github.com/Team-Umbba/Umbba-iOS/assets/75068759/2b6a8de4-b1f5-4bdb-9ce1-2b4253e25b2e" width ="250">|
|연결끊김팝업|<img src = "https://github.com/Team-Umbba/Umbba-iOS/assets/75068759/530411ab-28a8-4771-9270-c379fb7be7ac" width ="250">|


📟 **관련 이슈**

- Resolved: #185 
