### PR TITLE
[Fix] #231 - 회원탈퇴 뷰에서 BackButton 안되는 이슈 해결

### DIFF
--- a/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/WithdrawalViewController.swift
+++ b/Umbba-iOS/Umbba-iOS/Presentation/Setting/SettingScene/ViewController/WithdrawalViewController.swift
@@ -40,7 +40,7 @@ private extension WithdrawalViewController {
 extension WithdrawalViewController: NavigationBarDelegate {
     
     func backButtonTapped() {
-        self.dismiss(animated: false)
+        self.navigationController?.popViewController(animated: true)
     }
     
     func completeButtonTapped() {


### PR DESCRIPTION
## 🔥*Pull requests*

🪵 **작업한 브랜치**
- feature/#231

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
아라가 발견해준 회원탈퇴 뷰에서 BackButton 안되는 이슈 해결했습니다!

🚨 **질문**
<!-- 질문할 사항이 있다면 적어주세요. -->

📸 **스크린샷**
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

📟 **관련 이슈**
- Resolved: #231
